### PR TITLE
COP-9328: Create workflow for npm publish

### DIFF
--- a/.github/workflow/publish-cop-react-components-to-npm.yml
+++ b/.github/workflow/publish-cop-react-components-to-npm.yml
@@ -1,4 +1,4 @@
-name: Publish library to npm
+name: Publish cop-react-components to npm
 
 on:
   release:

--- a/.github/workflow/publish-to-npm.yml
+++ b/.github/workflow/publish-to-npm.yml
@@ -1,0 +1,22 @@
+name: Publish library to npm
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          registry-url: 'https://registry.npmjs.org'
+      - run: cd packages/components
+      - run: rm -rf node_modules
+      - run: yarn install --frozen-lockfile
+      - run: yarn compile
+      - run: yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Description
Created a workflow for publishing the library to npm.

### To test
Check that the component library gets published to https://www.npmjs.com/package/@ukhomeoffice/cop-react-components and that it is public and not private. If so, this has succeeded.