### PR TITLE
COP-9328: Fix npm publish workflow

### DIFF
--- a/.github/workflows/publish-cop-react-components-to-npm.yml
+++ b/.github/workflows/publish-cop-react-components-to-npm.yml
@@ -13,10 +13,16 @@ jobs:
         with:
           node-version: 12
           registry-url: 'https://registry.npmjs.org'
-      - run: cd packages/components
-      - run: rm -rf node_modules
-      - run: yarn install --frozen-lockfile
-      - run: yarn compile
-      - run: yarn publish
+      - name: Install dependencies
+        working-directory: ./packages/components
+        run: |
+          rm -rf node_modules
+          yarn install --frozen-lockfile
+      - name: Build package
+        working-directory: ./packages/components
+        run: yarn compile
+      - name: Publish package to npm
+        working-directory: ./packages/components
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "scripts": {
     "storybook": "start-storybook -p 6006",


### PR DESCRIPTION
## Description
The job needed to have a working-directory rather than navigating to the corresponding folder. It also seems that `yarn publish` doesn't work correctly for our needs as it prompts for the new version number.