### PR TITLE
COP-8970: Add Readonly component

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.jsx
+++ b/packages/components/src/Autocomplete/Autocomplete.jsx
@@ -1,10 +1,14 @@
+// Global imports
 import React, { useEffect, useRef } from 'react'
 import { default as AlphaAutocomplete } from 'accessible-autocomplete/react';
 import PropTypes from 'prop-types';
+
+// Local imports
 import { getFilterFunction, getTemplates, setValue } from './Autocomplete.utils';
+import Readonly from '../Readonly';
+import TextInput from '../TextInput';
 import { concatClasses } from '../utils/Utils';
 import './Autocomplete.scss';
-import { TextInput } from '..';
 
 export const DEFAULT_CLASS = 'hods-autocomplete';
 const Autocomplete = ({
@@ -12,6 +16,7 @@ const Autocomplete = ({
   fieldId,
   disabled,
   error,
+  readonly,
   source,
   item,
   value,
@@ -39,6 +44,13 @@ const Autocomplete = ({
       onChange({ target: { name: fieldId, value } });
     }
   };
+  if (readonly) {
+    return (
+      <Readonly id={id} className={className} {...attrs}>
+        {templates.inputValue(value)}
+      </Readonly>
+    );
+  }
   return (
     <div className={`${DEFAULT_CLASS}__outer-wrapper ${className ?? ''}`}>
       {disabled && <TextInput
@@ -66,10 +78,11 @@ const Autocomplete = ({
 };
 
 Autocomplete.propTypes = {
-  id: PropTypes.string,
-  fieldId: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  fieldId: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   error: PropTypes.string,
+  readonly: PropTypes.bool,
   /** A list of items or a function that takes a query and callback method, which is called with the resultant list of items. */
   source: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.any), PropTypes.func]).isRequired,
   /** The structure of the item. If this is not provided, it is assumed to be a string. */

--- a/packages/components/src/Autocomplete/Autocomplete.stories.mdx
+++ b/packages/components/src/Autocomplete/Autocomplete.stories.mdx
@@ -181,8 +181,8 @@ template looks like this: `'${label} (${value})'`.
       const clearValue = () => {
         setValue(null);
       };
-      const onChange = (item) => {
-        setValue(item);
+      const onChange = ({ target: { value } }) => {
+        setValue(value);
       };
       return (
         <form autoComplete="off">

--- a/packages/components/src/Autocomplete/Autocomplete.stories.mdx
+++ b/packages/components/src/Autocomplete/Autocomplete.stories.mdx
@@ -1,10 +1,13 @@
+<!-- Global imports -->
 import { useState, useEffect } from 'react';
-import { Meta, ArgsTable, Story, Canvas } from '@storybook/addon-docs';
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+
+<!-- Local imports -->
 import Autocomplete, { RefDataAutocomplete } from './Autocomplete';
+import { Countries, CountriesAsRefData, CountriesByName } from './Countries.stories';
 import Details from '../Details';
 import Label from '../Label';
 import { interpolateString } from '../utils/Utils';
-import { Countries, CountriesAsRefData, CountriesByName } from './Countries.stories';
 import './Autocomplete.stories.scss';
 
 <Meta title="Autocomplete" id="D-Autocomplete" component={ Autocomplete } />
@@ -21,6 +24,7 @@ Make a page easier to scan by letting users reveal more detailed information onl
           <Label id="default-autocomplete">Find your country of birth</Label>
           <Autocomplete
             id="default-autocomplete"
+            fieldId="default-autocomplete"
             source={CountriesByName}
             displayMenu="inline"
             showAllValues
@@ -61,6 +65,7 @@ In this example, the data items take the form `{ "value": "GB", "label": "United
           <Label id="object-autocomplete">Find your country of birth</Label>
           <Autocomplete
             id="object-autocomplete"
+            fieldId="object-autocomplete"
             source={filterCountries}
             item={{ value: 'value', label: 'label' }}
             displayMenu="inline"
@@ -86,6 +91,7 @@ template looks like this: `'${label} (${value})'`.
           <Label id="formatted-autocomplete">Find your country of birth</Label>
           <Autocomplete
             id="formatted-autocomplete"
+            fieldId="formatted-autocomplete"
             source={Countries}
             item={{ value: 'value', label: 'label', format: TEMPLATE }}
             displayMenu="inline"
@@ -106,6 +112,7 @@ template looks like this: `'${label} (${value})'`.
           <Label id="error-autocomplete">Find your country of birth</Label>
           <Autocomplete
             id="error-autocomplete"
+            fieldId="error-autocomplete"
             source={CountriesByName}
             displayMenu="inline"
             error="Error"
@@ -126,6 +133,7 @@ template looks like this: `'${label} (${value})'`.
           <Label id="disabled-autocomplete">Find your country of birth</Label>
           <Autocomplete
             id="disabled-autocomplete"
+            fieldId="disabled-autocomplete"
             source={CountriesByName}
             displayMenu="inline"
             disabled
@@ -146,6 +154,7 @@ template looks like this: `'${label} (${value})'`.
           <Label id="disabled-error-autocomplete">Find your country of birth</Label>
           <Autocomplete
             id="disabled-error-autocomplete"
+            fieldId="disabled-error-autocomplete"
             source={CountriesByName}
             displayMenu="inline"
             disabled
@@ -180,6 +189,7 @@ template looks like this: `'${label} (${value})'`.
           <Label id="initial-autocomplete">Find your country of birth</Label>
           <Autocomplete
             id="initial-autocomplete"
+            fieldId="initial-autocomplete"
             item={{ value: 'value', label: 'label' }}
             source={Countries}
             value={value}
@@ -211,8 +221,35 @@ Reference data items include `id` and `name` properties: `{ "id": "GB", "name": 
           <Label id="refdata-autocomplete">Find your country of birth</Label>
           <RefDataAutocomplete
             id="refdata-autocomplete"
+            fieldId="refdata-autocomplete"
             source={CountriesAsRefData}
             displayMenu="inline"
+          />
+        </form>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Readonly
+
+<Canvas>
+  <Story name="Readonly">
+    {() => {
+      const [value, setValue] = useState(Countries.find(c => c.value === 'GB'));
+      // eslint-disable-next-line no-template-curly-in-string
+      const TEMPLATE = '${label} (${value})';
+      return (
+        <form autoComplete="off">
+          <Label id="readonly-autocomplete">Find your country of birth</Label>
+          <Autocomplete
+            id="readonly-autocomplete"
+            fieldId="readonly-autocomplete"
+            item={{ value: 'value', label: 'label', format: TEMPLATE }}
+            source={Countries}
+            value={value}
+            displayMenu="inline"
+            readonly
           />
         </form>
       );

--- a/packages/components/src/Readonly/Readonly.jsx
+++ b/packages/components/src/Readonly/Readonly.jsx
@@ -1,0 +1,35 @@
+// Global imports
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Local imports
+import { classBuilder } from '../utils/Utils';
+import './Readonly.scss';
+
+export const DEFAULT_CLASS = 'hods-readonly';
+const Readonly = ({
+  children,
+  classBlock,
+  classModifiers,
+  className,
+  ...attrs
+}) => {
+  const classes = classBuilder(classBlock, classModifiers, className);
+  return (
+    <div {...attrs} className={classes()}>
+      {children}
+    </div>
+  );
+};
+
+Readonly.propTypes = {
+  classBlock: PropTypes.string,
+  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  className: PropTypes.string
+};
+
+Readonly.defaultProps = {
+  classBlock: DEFAULT_CLASS
+};
+
+export default Readonly;

--- a/packages/components/src/Readonly/Readonly.scss
+++ b/packages/components/src/Readonly/Readonly.scss
@@ -1,0 +1,3 @@
+.hods-readonly {
+  display: inline;
+}

--- a/packages/components/src/Readonly/Readonly.stories.mdx
+++ b/packages/components/src/Readonly/Readonly.stories.mdx
@@ -1,0 +1,44 @@
+<!-- Global imports -->
+import { Fragment } from 'react';
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+
+<!-- Local imports -->
+import Details from '../Details';
+import Label from '../Label';
+import Readonly from './Readonly';
+import Tag from '../Tag';
+
+<Meta title="Internal/Readonly" id="D-Readonly" component={ Readonly } />
+
+# Readonly
+
+<p><Tag text="Internal" /></p>
+
+A readonly version of a component, displaying as plain text.
+
+<Canvas>
+  <Story name="Default">
+    <Fragment>
+      <Label id="readonly" required>Are you a civil servant?</Label>
+      <Readonly id="readonly">Yes</Readonly>
+    </Fragment>
+  </Story>
+</Canvas>
+
+<Details summary="Properties" className="no-indent">
+  <ArgsTable of={ Readonly } />
+</Details>
+
+# Variants
+## With markup
+
+<Canvas>
+  <Story name="Markup">
+    <Readonly>
+      <ol>
+        <li>Check your answers carefully</li>
+        <li>Don't make a mistake</li>
+      </ol>
+    </Readonly>
+  </Story>
+</Canvas>

--- a/packages/components/src/Readonly/Readonly.test.js
+++ b/packages/components/src/Readonly/Readonly.test.js
@@ -1,0 +1,62 @@
+// Global imports
+import React from 'react';
+import { getByTestId, render } from '@testing-library/react';
+
+// Local imports
+import Readonly, { DEFAULT_CLASS } from './Readonly';
+
+describe('Readonly', () => {
+
+  it('should set up the component appropriately', async () => {
+    const ID = 'readonly';
+    const VALUE = 'Readonly text';
+    const { container } = render(
+      <Readonly data-testid={ID} id={ID}>{VALUE}</Readonly>
+    );
+    const readonly = getByTestId(container, ID);
+    expect(readonly.tagName).toEqual('DIV');
+    expect(readonly.classList).toContain(DEFAULT_CLASS);
+    expect(readonly.innerHTML).toEqual(VALUE);
+  });
+
+  it('should accept the classBlock parameter', async () => {
+    const ID = 'readonly';
+    const VALUE = 'Readonly text';
+    const CLASS_BLOCK = 'different-class-block';
+    const { container } = render(
+      <Readonly data-testid={ID} id={ID} classBlock={CLASS_BLOCK}>{VALUE}</Readonly>
+    );
+    const readonly = getByTestId(container, ID);
+    expect(readonly.classList).toContain(CLASS_BLOCK);
+    expect(readonly.innerHTML).toEqual(VALUE);
+  });
+
+  it('should accept the className parameter', async () => {
+    const ID = 'readonly';
+    const VALUE = 'Readonly text';
+    const CLASS_NAME = 'different-class-name';
+    const { container } = render(
+      <Readonly data-testid={ID} id={ID} className={CLASS_NAME}>{VALUE}</Readonly>
+    );
+    const readonly = getByTestId(container, ID);
+    expect(readonly.classList).toContain(DEFAULT_CLASS);
+    expect(readonly.classList).toContain(CLASS_NAME);
+    expect(readonly.innerHTML).toEqual(VALUE);
+  });
+
+  it('should accept the classModifiers parameter', async () => {
+    const ID = 'readonly';
+    const VALUE = 'Readonly text';
+    const CLASS_MODIFIERS = ['mod1', 'mod2'];
+    const { container } = render(
+      <Readonly data-testid={ID} id={ID} classModifiers={CLASS_MODIFIERS}>{VALUE}</Readonly>
+    );
+    const readonly = getByTestId(container, ID);
+    expect(readonly.classList).toContain(DEFAULT_CLASS);
+    CLASS_MODIFIERS.forEach(mod => {
+      expect(readonly.classList).toContain(`${DEFAULT_CLASS}--${mod}`);
+    });
+    expect(readonly.innerHTML).toEqual(VALUE);
+  });
+
+});

--- a/packages/components/src/Readonly/index.js
+++ b/packages/components/src/Readonly/index.js
@@ -1,0 +1,6 @@
+import Readonly, { DEFAULT_CLASS } from './Readonly';
+
+export default Readonly;
+export {
+  DEFAULT_CLASS
+};

--- a/packages/components/src/TextInput/TextInput.jsx
+++ b/packages/components/src/TextInput/TextInput.jsx
@@ -1,5 +1,9 @@
+// Global imports
 import React from 'react';
 import PropTypes from 'prop-types';
+
+// Local imports
+import Readonly from '../Readonly';
 import { classBuilder, toArray } from '../utils/Utils';
 import './TextInput.scss';
 
@@ -9,6 +13,7 @@ const TextInput = ({
   fieldId,
   disabled,
   error,
+  readonly,
   classBlock,
   classModifiers: _classModifiers,
   className,
@@ -16,6 +21,13 @@ const TextInput = ({
 }) => {
   const classModifiers = [...toArray(_classModifiers), error ? 'error' : undefined ];
   const classes = classBuilder(classBlock, classModifiers, className);
+  if (readonly) {
+    return (
+      <Readonly id={id} classModifiers={classModifiers} className={className} {...attrs}>
+        {attrs.value}
+      </Readonly>
+    );
+  }
   return (
     <input
       {...attrs}
@@ -33,6 +45,7 @@ TextInput.propTypes = {
   fieldId: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   error: PropTypes.string,
+  readonly: PropTypes.bool,
   classBlock: PropTypes.string,
   classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   className: PropTypes.string

--- a/packages/components/src/TextInput/TextInput.stories.mdx
+++ b/packages/components/src/TextInput/TextInput.stories.mdx
@@ -1,5 +1,8 @@
+<!-- Global imports -->
 import { useState } from 'react';
-import { Canvas, Meta, Props, Story } from '@storybook/addon-docs';
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+
+<!-- Local imports -->
 import Details from '../Details';
 import TextInput from './TextInput';
 
@@ -14,7 +17,7 @@ import TextInput from './TextInput';
 </Canvas>
 
 <Details summary="Properties" className="no-indent">
-  <Props of={ TextInput } />
+  <ArgsTable of={ TextInput } />
 </Details>
 
 # Variants
@@ -35,6 +38,16 @@ A text input in an error state.
 <Canvas>
   <Story name="Error">
     <TextInput id="errorInput" fieldId="errorInput" error="This is an error" />
+  </Story>
+</Canvas>
+
+## Readonly
+
+A readonly "input".
+
+<Canvas>
+  <Story name="Readonly">
+    <TextInput id="readonlyInput" fieldId="readonlyInput" value="This is readonly text." readonly />
   </Story>
 </Canvas>
 

--- a/packages/components/src/TextInput/TextInput.test.js
+++ b/packages/components/src/TextInput/TextInput.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fireEvent, getByTestId, render } from '@testing-library/react';
 import TextInput, { DEFAULT_CLASS } from './TextInput';
+import { DEFAULT_CLASS as DEFAULT_READONLY_CLASS } from '../Readonly';
 
 describe('TextInput', () => {
 
@@ -23,7 +24,7 @@ describe('TextInput', () => {
     expect(input.getAttribute('disabled')).toBeNull();
   });
 
-  it('should be accept the disabled flag', async () => {
+  it('should accept the disabled flag', async () => {
     const INPUT_ID = 'input';
     const INPUT_FIELD_ID = 'inputFieldId';
     const { container } = render(
@@ -31,6 +32,17 @@ describe('TextInput', () => {
     );
     const input = checkSetup(container, INPUT_ID);
     expect(input.getAttribute('disabled')).not.toBeNull();
+  });
+
+  it('should accept the readonly flag', async () => {
+    const INPUT_ID = 'input';
+    const INPUT_FIELD_ID = 'inputFieldId';
+    const { container } = render(
+      <TextInput data-testid={INPUT_ID} id={INPUT_ID} fieldId={INPUT_FIELD_ID} readonly={true} />
+    );
+    const input = getByTestId(container, INPUT_ID);
+    expect(input.tagName).toEqual('DIV');
+    expect(input.classList).toContain(DEFAULT_READONLY_CLASS);
   });
 
   it('should be in an error state when the error is set', async () => {

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -11,6 +11,7 @@ import Label from './Label';
 import Link from './Link';
 import Panel from './Panel';
 import Radios, { Radio } from './Radios';
+import Readonly from './Readonly';
 import Tag from './Tag';
 import TextInput from './TextInput';
 import Utils from './utils/Utils';
@@ -31,6 +32,7 @@ export {
   Panel,
   Radio,
   Radios,
+  Readonly,
   StartButton,
   Tag,
   TextInput,


### PR DESCRIPTION
### Description
Added a Readonly component for use within otherwise editable components when they are in a readonly state. This is distinct from a "disabled" state.
https://support.cop.homeoffice.gov.uk/browse/COP-8970

Also added accompanying unit test and Storybook stories.

### To test
The component library itself offers Storybook for the purposes of evaluating the rendering of the components and their variations. Proper testing will likely be best achieved when the components are used in COP-8193, COP-8376, and COP-8386, which will be within https://github.com/UKHomeOffice/cop-ui.

Instructions to see the components within Storybook are in the `README.md` files, but the TLDR version is to run the following in the project root (or in `packages/components`):
* `> yarn install`
* `> yarn storybook`