### PR TITLE
COP-9332: Deploy Storybook in CI mode

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -21,6 +21,6 @@ jobs:
         run: yarn build-storybook
       - name: Deploy Storybook
         working-directory: ./packages/components
-        run: yarn deploy-storybook
+        run: yarn deploy-storybook -- --ci --host-token-env-variable=GITHUB_TOKEN
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
### Description
Added flags to deploy in CI mode, as per the documentation. This was previously failing at the deploy stage, citing invalid credentials, which is what this should address - hence the use of `GITHUB_TOKEN`.

### To test
Check that the Storybook for the component library gets published to https://ukhomeoffice.github.io/cop-react-components/. If so, this has succeeded.
