### PR TITLE
COP-9332: Update workflow to use GH_TOKEN

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -18,9 +18,9 @@ jobs:
           yarn install --frozen-lockfile
       - name: Build static Storybook
         working-directory: ./packages/components
-        run: yarn build-storybook
+        run: yarn build-storybook -o=.out
       - name: Deploy Storybook
         working-directory: ./packages/components
-        run: yarn deploy-storybook -- --ci --host-token-env-variable=GITHUB_TOKEN
+        run: yarn deploy-storybook -- --ci -e=.out
         env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
### Description
Set the environment variable to be `GH_TOKEN`.

### To test
Check that the Storybook for the component library gets published to https://ukhomeoffice.github.io/cop-react-components/. If so, this has succeeded.