### PR TITLE
Set version to 0.3.0 for release

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,6 @@
 name: Build and test
 
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   build_and_test:

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "private": false,
   "scripts": {
     "storybook": "start-storybook -p 6006",


### PR DESCRIPTION
### Description
Set the version to 0.3.0 for a release.

Also removed the "push" trigger for the "Build and test" workflow so we don't get double runs when they're linked to a PR - it's enough to have it based on an attempt to merge.