### PR TITLE
COP-8972: Add formatted text component

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": false,
   "scripts": {
     "storybook": "start-storybook -p 6006",
@@ -18,6 +18,7 @@
     "@testing-library/user-event": "^12.1.10",
     "accessible-autocomplete": "2.0.3",
     "govuk-frontend": "^3.13.0",
+    "html-react-parser": "^0.10.5",
     "web-vitals": "^1.0.1"
   },
   "devDependencies": {

--- a/packages/components/src/Heading/Heading.jsx
+++ b/packages/components/src/Heading/Heading.jsx
@@ -1,0 +1,58 @@
+// Global imports
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Local imports
+import Markup from '../Markup';
+import './Heading.scss';
+
+const TAGS = { xl: 'h1', l: 'h2', m: 'h3', s: 'h3' };
+
+const getProps = (size) => {
+  const tagName = TAGS[size] || TAGS.l;
+  const className = `govuk-heading-${size}`;
+  if (size === 's') {
+    return { tagName, className };
+  }
+  const captionClass = `govuk-caption-${size}`;
+  return { tagName, className, captionClass };
+};
+
+const Heading = ({ children, size, caption, ...attrs }) => {
+  const { tagName, className, captionClass } = getProps(size);
+  return (
+    <Markup {...attrs} tagName={tagName} className={className}>
+      {caption && captionClass ? <span className={captionClass}>{caption}</span> : null}
+      {children}
+    </Markup>
+  );
+};
+
+Heading.propTypes = {
+  size: PropTypes.oneOf(['s', 'm', 'l', 'xl']),
+  caption: PropTypes.string
+};
+
+Heading.defaultProps = {
+  size: 'l'
+};
+
+export const XLargeHeading = ({ children, caption, ...attrs }) => {
+  return <Heading {...attrs} caption={caption} size="xl">{children}</Heading>;
+};
+
+export const LargeHeading = ({ children, caption, ...attrs }) => {
+  return <Heading {...attrs} caption={caption} size="l">{children}</Heading>;
+};
+
+export const MediumHeading = ({ children, caption, ...attrs }) => {
+  return <Heading {...attrs} caption={caption} size="m">{children}</Heading>;
+};
+
+export const SmallHeading = ({ children, caption, ...attrs }) => {
+  // Note that the caption is ignored here as it is not applicable
+  // for small headings.
+  return <Heading {...attrs} size="s">{children}</Heading>;
+};
+
+export default Heading;

--- a/packages/components/src/Heading/Heading.scss
+++ b/packages/components/src/Heading/Heading.scss
@@ -1,0 +1,1 @@
+@import "node_modules/govuk-frontend/govuk/core/typography";

--- a/packages/components/src/Heading/Heading.stories.mdx
+++ b/packages/components/src/Heading/Heading.stories.mdx
@@ -1,0 +1,39 @@
+<!-- Global imports -->
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+
+<!-- Local imports -->
+import Details from '../Details';
+import Heading, { LargeHeading, MediumHeading, SmallHeading, XLargeHeading } from './Heading';
+
+<Meta title="Heading" id="D-Heading" component={ Heading } />
+
+# Heading
+
+Render a heading tag in the specified size (`s`, `m`, `l`, or `xl`).
+
+<Canvas withToolbar>
+  <Story name="Default">
+    <XLargeHeading>govuk-heading-xl</XLargeHeading>
+    <LargeHeading>govuk-heading-l</LargeHeading>
+    <MediumHeading>govuk-heading-m</MediumHeading>
+    <SmallHeading>govuk-heading-s</SmallHeading>
+  </Story>
+</Canvas>
+
+<Details summary="Properties" className="no-indent">
+  <ArgsTable of={ Heading } />
+</Details>
+
+### Headings with captions
+Sometimes you may need to make it clear that a page is part of a larger section or group. To do this, you can use a heading with a caption above it.
+
+Note that small headings cannot have captions.
+
+<Canvas>
+  <Story name="Captions">
+    <XLargeHeading caption="govuk-caption-xl">govuk-heading-xl</XLargeHeading>
+    <LargeHeading caption="govuk-caption-l">govuk-heading-l</LargeHeading>
+    <MediumHeading caption="govuk-caption-m">govuk-heading-m</MediumHeading>
+    <SmallHeading caption="govuk-caption-s">govuk-heading-s</SmallHeading>
+  </Story>
+</Canvas>

--- a/packages/components/src/Heading/Heading.test.js
+++ b/packages/components/src/Heading/Heading.test.js
@@ -1,0 +1,181 @@
+// Global imports
+import React from 'react';
+import { getByTestId, render } from '@testing-library/react';
+
+// Local imports
+import Heading, { LargeHeading, MediumHeading, SmallHeading, XLargeHeading } from './Heading';
+
+describe('Heading', () => {
+  it(`should default to size of 'l'`, () => {
+    const ID = 'headingId';
+    const TEXT = 'Heading text';
+    const { container } = render(
+      <Heading data-testid={ID}>{TEXT}</Heading>
+    );
+    const heading = getByTestId(container, ID);
+    expect(heading.tagName).toEqual('H2');
+    expect(heading.innerHTML).toContain(TEXT);
+    expect(heading.classList).toContain('govuk-heading-l');
+  });
+
+  describe('known sizes', () => {
+    // s, m, l, and xl are known sizes
+    ['s', 'm', 'l', 'xl'].forEach(size => {
+      it(`should accept ${size} as a known size`, () => {
+        const ID = 'headingId';
+        const TEXT = 'Heading text';
+        const { container } = render(
+          <Heading data-testid={ID} size={size}>{TEXT}</Heading>
+        );
+        const heading = getByTestId(container, ID);
+        expect(heading.innerHTML).toContain(TEXT);
+        expect(heading.classList).toContain(`govuk-heading-${size}`);
+      });
+    });
+  });
+
+  describe('unknown sizes', () => {
+    const spy = { console: undefined };
+    const errorMessages = [];
+    beforeEach(() => {
+      spy.console = jest.spyOn(console, 'error').mockImplementation((message, ...optionalParams) => {
+        errorMessages.push({ ...optionalParams, message });
+      });
+    });
+    afterEach(() => {
+      spy.console.mockRestore();
+      errorMessages.length = 0;
+    });
+    it('should reject a size other than the known ones', () => {
+      const ID = 'headingId';
+      const TEXT = 'Heading text';
+      const SIZE = 'bob';
+      render(
+        <Heading data-testid={ID} size={SIZE}>{TEXT}</Heading>
+      );
+      expect(console.error).toHaveBeenCalled();
+      expect(errorMessages.length).toEqual(1);
+      expect(errorMessages[0][1]).toContain(`Invalid prop \`size\` of value \`${SIZE}\` supplied to \`Heading\``);
+    });
+  });
+});
+
+describe('XLargeHeading', () => {
+  it('should render as an h1 with an appropriate class', () => {
+    const ID = 'headingId';
+    const TEXT = 'Heading text';
+    const { container } = render(
+      <XLargeHeading data-testid={ID}>{TEXT}</XLargeHeading>
+    );
+    const heading = getByTestId(container, ID);
+    expect(heading.tagName).toEqual('H1');
+    expect(heading.innerHTML).toContain(TEXT);
+    expect(heading.classList).toContain('govuk-heading-xl');
+  });
+  it('should accept a caption where specified', () => {
+    const ID = 'headingId';
+    const TEXT = 'Heading text';
+    const CAPTION = 'Caption text';
+    const { container } = render(
+      <XLargeHeading data-testid={ID} caption={CAPTION}>{TEXT}</XLargeHeading>
+    );
+    const heading = getByTestId(container, ID);
+    expect(heading.tagName).toEqual('H1');
+    expect(heading.innerHTML).toContain(TEXT);
+    expect(heading.classList).toContain('govuk-heading-xl');
+    expect(heading.childNodes.length).toEqual(2);
+    const caption = heading.childNodes[0];
+    expect(caption.tagName).toEqual('SPAN');
+    expect(caption.innerHTML).toContain(CAPTION);
+    expect(caption.classList).toContain('govuk-caption-xl');
+  });
+});
+
+describe('LargeHeading', () => {
+  it('should render as an h2 with an appropriate class', () => {
+    const ID = 'headingId';
+    const TEXT = 'Heading text';
+    const { container } = render(
+      <LargeHeading data-testid={ID}>{TEXT}</LargeHeading>
+    );
+    const heading = getByTestId(container, ID);
+    expect(heading.tagName).toEqual('H2');
+    expect(heading.innerHTML).toContain(TEXT);
+    expect(heading.classList).toContain('govuk-heading-l');
+  });
+  it('should accept a caption where specified', () => {
+    const ID = 'headingId';
+    const TEXT = 'Heading text';
+    const CAPTION = 'Caption text';
+    const { container } = render(
+      <LargeHeading data-testid={ID} caption={CAPTION}>{TEXT}</LargeHeading>
+    );
+    const heading = getByTestId(container, ID);
+    expect(heading.tagName).toEqual('H2');
+    expect(heading.innerHTML).toContain(TEXT);
+    expect(heading.classList).toContain('govuk-heading-l');
+    expect(heading.childNodes.length).toEqual(2);
+    const caption = heading.childNodes[0];
+    expect(caption.tagName).toEqual('SPAN');
+    expect(caption.innerHTML).toContain(CAPTION);
+    expect(caption.classList).toContain('govuk-caption-l');
+  });
+});
+
+describe('MediumHeading', () => {
+  it('should render as an h3 with an appropriate class', () => {
+    const ID = 'headingId';
+    const TEXT = 'Heading text';
+    const { container } = render(
+      <MediumHeading data-testid={ID}>{TEXT}</MediumHeading>
+    );
+    const heading = getByTestId(container, ID);
+    expect(heading.tagName).toEqual('H3');
+    expect(heading.innerHTML).toContain(TEXT);
+    expect(heading.classList).toContain('govuk-heading-m');
+  });
+  it('should accept a caption where specified', () => {
+    const ID = 'headingId';
+    const TEXT = 'Heading text';
+    const CAPTION = 'Caption text';
+    const { container } = render(
+      <MediumHeading data-testid={ID} caption={CAPTION}>{TEXT}</MediumHeading>
+    );
+    const heading = getByTestId(container, ID);
+    expect(heading.tagName).toEqual('H3');
+    expect(heading.innerHTML).toContain(TEXT);
+    expect(heading.classList).toContain('govuk-heading-m');
+    expect(heading.childNodes.length).toEqual(2);
+    const caption = heading.childNodes[0];
+    expect(caption.tagName).toEqual('SPAN');
+    expect(caption.innerHTML).toContain(CAPTION);
+    expect(caption.classList).toContain('govuk-caption-m');
+  });
+});
+
+describe('SmallHeading', () => {
+  it('should render as an h3 with an appropriate class', () => {
+    const ID = 'headingId';
+    const TEXT = 'Heading text';
+    const { container } = render(
+      <SmallHeading data-testid={ID}>{TEXT}</SmallHeading>
+    );
+    const heading = getByTestId(container, ID);
+    expect(heading.tagName).toEqual('H3');
+    expect(heading.innerHTML).toContain(TEXT);
+    expect(heading.classList).toContain('govuk-heading-s');
+  });
+  it('should ignore a caption where specified', () => {
+    const ID = 'headingId';
+    const TEXT = 'Heading text';
+    const CAPTION = 'Caption text';
+    const { container } = render(
+      <SmallHeading data-testid={ID} caption={CAPTION}>{TEXT}</SmallHeading>
+    );
+    const heading = getByTestId(container, ID);
+    expect(heading.tagName).toEqual('H3');
+    expect(heading.innerHTML).toContain(TEXT);
+    expect(heading.classList).toContain('govuk-heading-s');
+    expect(heading.childNodes.length).toEqual(1);
+  });
+});

--- a/packages/components/src/Heading/index.js
+++ b/packages/components/src/Heading/index.js
@@ -1,0 +1,9 @@
+import Heading, { LargeHeading, MediumHeading, SmallHeading, XLargeHeading } from './Heading';
+
+export default Heading;
+export {
+  LargeHeading,
+  MediumHeading,
+  SmallHeading,
+  XLargeHeading
+};

--- a/packages/components/src/Markup/Markup.jsx
+++ b/packages/components/src/Markup/Markup.jsx
@@ -1,0 +1,22 @@
+// Global imports
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const DEFAULT_TAG_NAME = 'p';
+const Markup = ({ children, tagName, className, ...attrs }) => {
+  const Tag = `${tagName}`;
+  return <Tag {...attrs} className={className}>
+    {children}
+  </Tag>;
+};
+
+Markup.propTypes = {
+  tagName: PropTypes.string.isRequired,
+  className: PropTypes.string
+};
+
+Markup.defaultProps = {
+  tagName: DEFAULT_TAG_NAME
+};
+
+export default Markup;

--- a/packages/components/src/Markup/Markup.jsx
+++ b/packages/components/src/Markup/Markup.jsx
@@ -1,17 +1,31 @@
 // Global imports
-import React from 'react';
+import parse from 'html-react-parser';
 import PropTypes from 'prop-types';
+import React from 'react';
 
+/**
+ * The following list has been taken from w3.org:
+ * https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#void-elements
+ */
+export const VOID_ELEMENTS = [
+  'area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 'input',
+  'keygen', 'link', 'meta', 'param', 'source', 'track', 'wbr'
+];
 export const DEFAULT_TAG_NAME = 'p';
-const Markup = ({ children, tagName, className, ...attrs }) => {
+const Markup = ({ children, tagName, className, content, ...attrs }) => {
   const Tag = `${tagName}`;
+  if (VOID_ELEMENTS.includes(Tag)) {
+    return <Tag {...attrs} className={className} />;
+  }
   return <Tag {...attrs} className={className}>
-    {children}
+    {content && parse(content)}
+    {!content && children}
   </Tag>;
 };
 
 Markup.propTypes = {
   tagName: PropTypes.string.isRequired,
+  content: PropTypes.string,
   className: PropTypes.string
 };
 

--- a/packages/components/src/Markup/Markup.stories.mdx
+++ b/packages/components/src/Markup/Markup.stories.mdx
@@ -1,0 +1,55 @@
+<!-- Global imports -->
+
+import { useState } from 'react';
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+
+<!-- Local imports -->
+import Details from '../Details';
+import Tag from '../Tag';
+import Markup from './Markup';
+
+<Meta title="internal/Markup" id="D-FormattedText" component={ Markup } />
+
+# Markup
+
+<p><Tag text="Internal" /></p>
+
+An element for displaying formatted text - e.g., a paragraph or heading. By default, this will be a paragraph (`p`).
+
+<Canvas>
+  <Story name="Default">
+    <Markup>
+      The changes will show in your profile when they accept your request.
+    </Markup>
+  </Story>
+</Canvas>
+
+<Details summary="Properties" className="no-indent">
+  <ArgsTable of={ Markup } />
+</Details>
+
+## Stories
+### With `tagName`.
+
+The content can be additional markup, not just plain text, and the `tagName` can be appropriately specified.
+
+<Canvas>
+  <Story name="With specified tagName">
+    <Markup tagName="ol">
+      <li>Check your answers carefully</li>
+      <li>Don't make a mistake</li>
+    </Markup>
+  </Story>
+</Canvas>
+
+### With `className`.
+
+You can specify a `className` for styling purposes.
+
+<Canvas>
+  <Story name="With specified className">
+    <Markup tagName="h1" className="govuk-heading-l">
+      Large heading
+    </Markup>
+  </Story>
+</Canvas>

--- a/packages/components/src/Markup/Markup.stories.mdx
+++ b/packages/components/src/Markup/Markup.stories.mdx
@@ -1,6 +1,4 @@
 <!-- Global imports -->
-
-import { useState } from 'react';
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 
 <!-- Local imports -->
@@ -36,8 +34,8 @@ The content can be additional markup, not just plain text, and the `tagName` can
 <Canvas>
   <Story name="With specified tagName">
     <Markup tagName="ol">
-      <li>Check your answers carefully</li>
-      <li>Don't make a mistake</li>
+      <li key="check">Check your answers carefully</li>
+      <li key="mistake">Don't make a mistake</li>
     </Markup>
   </Story>
 </Canvas>
@@ -51,5 +49,17 @@ You can specify a `className` for styling purposes.
     <Markup tagName="h1" className="govuk-heading-l">
       Large heading
     </Markup>
+  </Story>
+</Canvas>
+
+### Horizontal rule
+
+Empty elements, such as `<hr />`, are also possible.
+
+<Canvas>
+  <Story name="Horizontal rule">
+    <p>Some text...</p>
+    <Markup tagName="hr" />
+    <p>... and then some further text below the horizontal rule.</p>
   </Story>
 </Canvas>

--- a/packages/components/src/Markup/Markup.test.js
+++ b/packages/components/src/Markup/Markup.test.js
@@ -1,0 +1,67 @@
+// Global imports
+import React from 'react';
+import { getByTestId, render } from '@testing-library/react';
+
+// Local imports
+import Markup, { DEFAULT_TAG_NAME } from './Markup';
+
+describe('Markup', () => {
+
+  it('should display the appropriate text', async () => {
+    const MARKUP_ID = 'markupId';
+    const TEXT = 'Hello World';
+    const { container } = render(
+      <Markup data-testid={MARKUP_ID}>{TEXT}</Markup>
+    );
+    const markup = getByTestId(container, MARKUP_ID);
+    expect(markup.innerHTML).toEqual(TEXT);
+    expect(markup.tagName).toEqual(DEFAULT_TAG_NAME.toUpperCase());
+  });
+
+  it('should use the appropriate tagName', async () => {
+    const MARKUP_ID = 'markupId';
+    const TEXT = 'Hello World';
+    const TAG_NAME = 'div';
+    const { container } = render(
+      <Markup data-testid={MARKUP_ID} tagName={TAG_NAME}>{TEXT}</Markup>
+    );
+    const markup = getByTestId(container, MARKUP_ID);
+    expect(markup.innerHTML).toEqual(TEXT);
+    expect(markup.tagName).toEqual(TAG_NAME.toUpperCase());
+  });
+
+  it('should use the appropriate className', async () => {
+    const MARKUP_ID = 'markupId';
+    const TEXT = 'Hello World';
+    const TAG_NAME = 'h1';
+    const CLASS_NAME = 'govuk-heading-l';
+    const { container } = render(
+      <Markup data-testid={MARKUP_ID} tagName={TAG_NAME} className={CLASS_NAME}>{TEXT}</Markup>
+    );
+    const markup = getByTestId(container, MARKUP_ID);
+    expect(markup.innerHTML).toEqual(TEXT);
+    expect(markup.tagName).toEqual(TAG_NAME.toUpperCase());
+    expect(markup.classList).toContain(CLASS_NAME);
+  });
+
+  it('should accept internal markup as well as text and render it appropriately', async () => {
+    const MARKUP_ID = 'markupId';
+    const TAG_NAME = 'h1';
+    const CLASS_NAME = 'govuk-heading-l';
+    const INNER_TEXT = 'Hello world!';
+    const INNER_TAG_NAME = 'span';
+    const { container } = render(
+      <Markup data-testid={MARKUP_ID} tagName={TAG_NAME} className={CLASS_NAME}>
+        <Markup tagName={INNER_TAG_NAME}>{INNER_TEXT}</Markup>
+      </Markup>
+    );
+    const markup = getByTestId(container, MARKUP_ID);
+    expect(markup.tagName).toEqual(TAG_NAME.toUpperCase());
+    expect(markup.classList).toContain(CLASS_NAME);
+    expect(markup.childNodes.length).toEqual(1);
+    const innerSpan = markup.childNodes[0];
+    expect(innerSpan.innerHTML).toEqual(INNER_TEXT);
+    expect(innerSpan.tagName).toEqual(INNER_TAG_NAME.toUpperCase());
+  });
+
+});

--- a/packages/components/src/Markup/Markup.test.js
+++ b/packages/components/src/Markup/Markup.test.js
@@ -30,6 +30,16 @@ describe('Markup', () => {
     expect(markup.tagName).toEqual(TAG_NAME.toUpperCase());
   });
 
+  it('should handle a void element', async () => {
+    const MARKUP_ID = 'markupId';
+    const TAG_NAME = 'hr';
+    const { container } = render(
+      <Markup data-testid={MARKUP_ID} tagName={TAG_NAME} />
+    );
+    const markup = getByTestId(container, MARKUP_ID);
+    expect(markup.tagName).toEqual(TAG_NAME.toUpperCase());
+  });
+
   it('should use the appropriate className', async () => {
     const MARKUP_ID = 'markupId';
     const TEXT = 'Hello World';

--- a/packages/components/src/Markup/index.js
+++ b/packages/components/src/Markup/index.js
@@ -1,0 +1,6 @@
+import Markup, { DEFAULT_TAG_NAME } from './Markup';
+
+export default Markup;
+export {
+  DEFAULT_TAG_NAME
+};

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -5,7 +5,7 @@ import ButtonGroup from './ButtonGroup';
 import Details from './Details';
 import FormGroup from './FormGroup';
 import ErrorMessage from './ErrorMessage';
-import { ErrorSummary } from './ErrorSummary';
+import ErrorSummary from './ErrorSummary';
 import Heading, { LargeHeading, MediumHeading, SmallHeading, XLargeHeading } from './Heading';
 import Hint from './Hint';
 import InsetText from './InsetText';

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -5,6 +5,8 @@ import ButtonGroup from './ButtonGroup';
 import Details from './Details';
 import FormGroup from './FormGroup';
 import ErrorMessage from './ErrorMessage';
+import { ErrorSummary } from './ErrorSummary';
+import Heading, { LargeHeading, MediumHeading, SmallHeading, XLargeHeading } from './Heading';
 import Hint from './Hint';
 import InsetText from './InsetText';
 import Label from './Label';
@@ -25,19 +27,25 @@ export {
   ButtonGroup,
   Details,
   ErrorMessage,
+  ErrorSummary,
   FormGroup,
+  Heading,
   Hint,
   InsetText,
   Label,
+  LargeHeading,
   Link,
   Markup,
+  MediumHeading,
   Panel,
   Radio,
   Radios,
   Readonly,
+  SmallHeading,
   StartButton,
   Tag,
   TextInput,
   Utils,
-  VisuallyHidden
+  VisuallyHidden,
+  XLargeHeading
 };

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -9,6 +9,7 @@ import Hint from './Hint';
 import InsetText from './InsetText';
 import Label from './Label';
 import Link from './Link';
+import Markup from './Markup';
 import Panel from './Panel';
 import Radios, { Radio } from './Radios';
 import Readonly from './Readonly';
@@ -29,6 +30,7 @@ export {
   InsetText,
   Label,
   Link,
+  Markup,
   Panel,
   Radio,
   Radios,

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -2909,6 +2909,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/domhandler@2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@types/domhandler/-/domhandler-2.4.1.tgz#7b3b347f7762180fbcb1ece1ce3dd0ebbb8c64cf"
+  integrity sha512-cfBw6q6tT5sa1gSPFSRKzF/xxYrrmeiut7E0TxNBObiLSBTuFEHibcfEe3waQPEDbqBsq+ql/TOniw65EyDFMA==
+
 "@types/eslint@^7.2.6":
   version "7.28.2"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.28.2.tgz#0ff2947cdd305897c52d5372294e8c76f351db68"
@@ -6002,7 +6007,7 @@ domain-browser@^1.1.1:
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
   integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
 
-domelementtype@1:
+domelementtype@1, domelementtype@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
   integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
@@ -6019,6 +6024,13 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
+domhandler@2.4.2, domhandler@^2.3.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
+  integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
+  dependencies:
+    domelementtype "1"
+
 domhandler@^4.0.0, domhandler@^4.2.0:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.2.2.tgz#e825d721d19a86b8c201a35264e226c678ee755f"
@@ -6026,7 +6038,7 @@ domhandler@^4.0.0, domhandler@^4.2.0:
   dependencies:
     domelementtype "^2.2.0"
 
-domutils@^1.7.0:
+domutils@^1.5.1, domutils@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
   integrity sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==
@@ -6236,6 +6248,11 @@ enquirer@^2.3.5:
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
   dependencies:
     ansi-colors "^4.1.1"
+
+entities@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
+  integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
 entities@^2.0.0:
   version "2.2.0"
@@ -7860,6 +7877,15 @@ hsla-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
 
+html-dom-parser@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/html-dom-parser/-/html-dom-parser-0.2.3.tgz#bfee592fc01c12bac08dcfa5da2611f9559a1812"
+  integrity sha512-GdzE63/U0IQEvcpAz0cUdYx2zQx0Ai+HWvE9TXEgwP27+SymUzKa7iB4DhjYpf2IdNLfTTOBuMS5nxeWOosSMQ==
+  dependencies:
+    "@types/domhandler" "2.4.1"
+    domhandler "2.4.2"
+    htmlparser2 "3.10.1"
+
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"
@@ -7894,6 +7920,16 @@ html-minifier-terser@^5.0.1:
     param-case "^3.0.3"
     relateurl "^0.2.7"
     terser "^4.6.3"
+
+html-react-parser@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/html-react-parser/-/html-react-parser-0.10.5.tgz#d05e3efd8ffaff692007b99b5b7d54f05a6c5f37"
+  integrity sha512-rtMWZ7KZjd9sO8jyIX7am0vGCIL45tCmctTnassT/BrTGeTaAZ4nQyqoGcx2v+vB8CAY+Q5PZiiV6eOiowq8dQ==
+  dependencies:
+    "@types/domhandler" "2.4.1"
+    html-dom-parser "0.2.3"
+    react-property "1.0.1"
+    style-to-object "0.3.0"
 
 html-tags@^3.1.0:
   version "3.1.0"
@@ -7934,6 +7970,18 @@ html-webpack-plugin@^4.0.0:
     pretty-error "^2.1.1"
     tapable "^1.1.3"
     util.promisify "1.0.0"
+
+htmlparser2@3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
+  integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
+  dependencies:
+    domelementtype "^1.3.1"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^3.1.1"
 
 htmlparser2@^6.1.0:
   version "6.1.0"
@@ -12287,6 +12335,11 @@ react-popper@^2.2.4:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
+react-property@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/react-property/-/react-property-1.0.1.tgz#4ae4211557d0a0ae050a71aa8ad288c074bea4e6"
+  integrity sha512-1tKOwxFn3dXVomH6pM9IkLkq2Y8oh+fh/lYW3MJ/B03URswUTqttgckOlbxY2XHF3vPG6uanSc4dVsLW/wk3wQ==
+
 react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
@@ -12452,7 +12505,7 @@ read-pkg@^5.2.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.6, readable-stream@^3.6.0:
+readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==


### PR DESCRIPTION
### Description
Added a `Markup` component, along with a specialised form of this in the `Heading` component.

Also added unit tests and Storybook stories for both.
https://support.cop.homeoffice.gov.uk/browse/COP-8972

### To test
The component library itself offers Storybook for the purposes of evaluating the rendering of the components and their variations. Proper testing will likely be best achieved when the components are used in COP-8193, COP-8376, and COP-8386, which will be within https://github.com/UKHomeOffice/cop-ui.

Instructions to see the components within Storybook are in the `README.md` files, but the TLDR version is to run the following in the project root (or in `packages/components`):
* `> yarn install`
* `> yarn storybook`

