### PR TITLE
COP-9578: Readonly Radios component

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": false,
   "scripts": {
     "storybook": "start-storybook -p 6006",

--- a/packages/components/src/ErrorSummary/ErrorSummary.scss
+++ b/packages/components/src/ErrorSummary/ErrorSummary.scss
@@ -1,1 +1,2 @@
+@import "node_modules/govuk-frontend/govuk/_base";
 @import "node_modules/govuk-frontend/govuk/components/error-summary";

--- a/packages/components/src/Heading/Heading.scss
+++ b/packages/components/src/Heading/Heading.scss
@@ -1,1 +1,2 @@
+@import "node_modules/govuk-frontend/govuk/_base";
 @import "node_modules/govuk-frontend/govuk/core/typography";

--- a/packages/components/src/Radios/Radios.jsx
+++ b/packages/components/src/Radios/Radios.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 
 // Local imports
 import Radio from './Radio';
+import Readonly from '../Readonly';
 import { classBuilder } from '../utils/Utils';
 import './Radios.scss';
 
@@ -11,6 +12,7 @@ export const DEFAULT_CLASS = 'govuk-radios';
 const Radios = ({
   id,
   fieldId,
+  readonly,
   options,
   value,
   onChange,
@@ -20,6 +22,15 @@ const Radios = ({
   ...attrs
 }) => {
   const classes = classBuilder(classBlock, classModifiers, className);
+  if (readonly) {
+    const selectedValue = typeof(value) === 'object' ? value?.value : value;
+    const selectedOption = options ? options.find(option => option.value === selectedValue) : undefined;
+    return (
+      <Readonly id={id} className={className} {...attrs}>
+        {selectedOption?.label}
+      </Readonly>
+    );
+  }
   return (
     <div id={id} className={classes()} onChange={onChange} {...attrs}>
       {options && options.map((option, index) => {

--- a/packages/components/src/Radios/Radios.stories.mdx
+++ b/packages/components/src/Radios/Radios.stories.mdx
@@ -397,6 +397,38 @@ Error messages should be styled like this:
 Make sure errors follow the guidance in error message and have specific error
 messages for specific error states.
 
+### Readonly
+
+A readonly rendering of the component, which shows only the label of the selected item
+without any of the other options. This can be used in a **Check your answers** pattern,
+for example.
+
+<Canvas>
+  <Story name="Readonly">
+    {() => {
+      const OPTIONS = [
+        { value: 'england', label: 'England' },
+        { value: 'scotland', label: 'Scotland' },
+        { value: 'wales', label: 'Wales' },
+        { value: 'northern-ireland', label: 'Northern Ireland' }
+      ];
+      const value = OPTIONS[0];
+      return (
+        <FormGroup
+          id="readonly"
+          label={<h1 className="govuk-heading-l">Where do you live?</h1>}>
+          <Radios
+            id="readonly-option"
+            fieldId="where-do-you-live-readonly"
+            options={OPTIONS}
+            readonly
+            value={value}
+          />
+        </FormGroup>
+      );
+    }}
+  </Story>
+</Canvas>
 
 #### If nothing is selected and the options are ‘yes’ and ‘no’
 

--- a/packages/components/src/Radios/Radios.test.js
+++ b/packages/components/src/Radios/Radios.test.js
@@ -4,6 +4,7 @@ import { fireEvent, getByTestId, render } from '@testing-library/react';
 
 // Local imports
 import Radios, { DEFAULT_CLASS } from './Radios';
+import { DEFAULT_CLASS as DEFAULT_READONLY_CLASS } from '../Readonly';
 
 describe('Radios', () => {
 
@@ -85,6 +86,18 @@ describe('Radios', () => {
     fireEvent.click(input);
     expect(CHANGE_EVENTS.length).toEqual(1);
     expect(CHANGE_EVENTS[0]).toEqual(OPTIONS[2].value);
+  });
+
+  it('should accept the readonly flag', async () => {
+    const ID = 'radio';
+    const FIELD_ID = 'fieldId';
+    const { container } = render(
+      <Radios data-testid={ID} id={ID} fieldId={FIELD_ID} options={OPTIONS} value={OPTIONS[0]} readonly={true} />
+    );
+    const radios = getByTestId(container, ID);
+    expect(radios.tagName).toEqual('DIV');
+    expect(radios.classList).toContain(DEFAULT_READONLY_CLASS);
+    expect(radios.innerHTML).toContain(OPTIONS[0].label);
   });
 
 });


### PR DESCRIPTION
### Description
Added an option to display the `Radios` component in a readonly format. This shows just the selected option as label text, which is distinct from a disabled component that shows all of the options in a disabled state.

### To test
This will most prominently be visible on the **Check your answers** screen where there is an underlying `Radios` component on the corresponding page/section.