### PR TITLE
Chore: code clean ups

### DIFF
--- a/src/Autocomplete/Autocomplete.stories.mdx
+++ b/src/Autocomplete/Autocomplete.stories.mdx
@@ -4,7 +4,7 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 
 <!-- Local imports -->
 import Autocomplete, { RefDataAutocomplete } from './Autocomplete';
-import { Countries, CountriesAsRefData, CountriesByName } from './Countries.stories';
+import { Countries, CountriesAsRefData, CountriesByName } from './Countries.stories.test';
 import Details from '../Details';
 import Label from '../Label';
 import { interpolateString } from '../utils/Utils';

--- a/src/Autocomplete/Countries.stories.test.js
+++ b/src/Autocomplete/Countries.stories.test.js
@@ -22,3 +22,7 @@ const setupCountries = () => {
 };
 
 setupCountries();
+
+it('should be a function', () => {
+  expect(typeof setupCountries).toEqual('function');
+});

--- a/src/FormGroup/FormGroup.stories.mdx
+++ b/src/FormGroup/FormGroup.stories.mdx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Canvas, Meta, Props, Story } from '@storybook/addon-docs';
 import Autocomplete from '../Autocomplete/Autocomplete';
-import { CountriesByName } from '../Autocomplete/Countries.stories';
+import { CountriesByName } from '../Autocomplete/Countries.stories.test';
 import Details from '../Details';
 import FormGroup from './FormGroup';
 import Tag from '../Tag';

--- a/src/Heading/Heading.jsx
+++ b/src/Heading/Heading.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import Markup from '../Markup';
 import './Heading.scss';
 
-const TAGS = { xl: 'h1', l: 'h2', m: 'h3', s: 'h3' };
+const TAGS = { xl: 'h1', l: 'h1', m: 'h2', s: 'h3' };
 
 const getProps = (size) => {
   const tagName = TAGS[size] || TAGS.l;

--- a/src/Heading/Heading.test.js
+++ b/src/Heading/Heading.test.js
@@ -13,7 +13,7 @@ describe('Heading', () => {
       <Heading data-testid={ID}>{TEXT}</Heading>
     );
     const heading = getByTestId(container, ID);
-    expect(heading.tagName).toEqual('H2');
+    expect(heading.tagName).toEqual('H1');
     expect(heading.innerHTML).toContain(TEXT);
     expect(heading.classList).toContain('govuk-heading-l');
   });
@@ -92,14 +92,14 @@ describe('XLargeHeading', () => {
 });
 
 describe('LargeHeading', () => {
-  it('should render as an h2 with an appropriate class', () => {
+  it('should render as an h1 with an appropriate class', () => {
     const ID = 'headingId';
     const TEXT = 'Heading text';
     const { container } = render(
       <LargeHeading data-testid={ID}>{TEXT}</LargeHeading>
     );
     const heading = getByTestId(container, ID);
-    expect(heading.tagName).toEqual('H2');
+    expect(heading.tagName).toEqual('H1');
     expect(heading.innerHTML).toContain(TEXT);
     expect(heading.classList).toContain('govuk-heading-l');
   });
@@ -111,7 +111,7 @@ describe('LargeHeading', () => {
       <LargeHeading data-testid={ID} caption={CAPTION}>{TEXT}</LargeHeading>
     );
     const heading = getByTestId(container, ID);
-    expect(heading.tagName).toEqual('H2');
+    expect(heading.tagName).toEqual('H1');
     expect(heading.innerHTML).toContain(TEXT);
     expect(heading.classList).toContain('govuk-heading-l');
     expect(heading.childNodes.length).toEqual(2);
@@ -123,14 +123,14 @@ describe('LargeHeading', () => {
 });
 
 describe('MediumHeading', () => {
-  it('should render as an h3 with an appropriate class', () => {
+  it('should render as an h2 with an appropriate class', () => {
     const ID = 'headingId';
     const TEXT = 'Heading text';
     const { container } = render(
       <MediumHeading data-testid={ID}>{TEXT}</MediumHeading>
     );
     const heading = getByTestId(container, ID);
-    expect(heading.tagName).toEqual('H3');
+    expect(heading.tagName).toEqual('H2');
     expect(heading.innerHTML).toContain(TEXT);
     expect(heading.classList).toContain('govuk-heading-m');
   });
@@ -142,7 +142,7 @@ describe('MediumHeading', () => {
       <MediumHeading data-testid={ID} caption={CAPTION}>{TEXT}</MediumHeading>
     );
     const heading = getByTestId(container, ID);
-    expect(heading.tagName).toEqual('H3');
+    expect(heading.tagName).toEqual('H2');
     expect(heading.innerHTML).toContain(TEXT);
     expect(heading.classList).toContain('govuk-heading-m');
     expect(heading.childNodes.length).toEqual(2);


### PR DESCRIPTION
### Description
1. Renamed `Countries.stories.js` to `Countries.stories.test.js` and added a basic test to it so that the file, which is used _purely_ for Storybook stories doesn't feature in the coverage analysis.

2. Following conversation with UX team, the large Heading should be an `<h1 />` as it is quite rare that we will use an extra large heading and, semantically, there should always be an `<h1 />` on the page. The medium heading has therefore also moved up to be an `<h2 />`.