### PR TITLE
COP-10048: Add TextArea component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/TextArea/TextArea.jsx
+++ b/src/TextArea/TextArea.jsx
@@ -1,0 +1,65 @@
+// Global imports
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Local imports
+import Readonly from '../Readonly';
+import { classBuilder, toArray } from '../utils/Utils';
+import './TextArea.scss';
+
+export const DEFAULT_ROWS = 5;
+export const DEFAULT_CLASS = 'govuk-textarea';
+const TextArea = ({
+  id,
+  fieldId,
+  rows,
+  disabled,
+  error,
+  readonly,
+  classBlock,
+  classModifiers: _classModifiers,
+  className,
+  ...attrs
+}) => {
+  const classModifiers = [...toArray(_classModifiers), error ? 'error' : undefined ];
+  const classes = classBuilder(classBlock, classModifiers, className);
+  if (readonly) {
+    return (
+      <Readonly id={id} classModifiers={classModifiers} className={className} {...attrs}>
+        {attrs.value}
+      </Readonly>
+    );
+  }
+  return (
+    <textarea
+      {...attrs}
+      disabled={disabled}
+      id={id}
+      name={fieldId}
+      rows={rows}
+      className={classes()}
+    />
+  );
+};
+
+TextArea.propTypes = {
+  id: PropTypes.string.isRequired,
+  fieldId: PropTypes.string.isRequired,
+  rows: PropTypes.number.isRequired,
+  disabled: PropTypes.bool,
+  error: PropTypes.string,
+  readonly: PropTypes.bool,
+  classBlock: PropTypes.string,
+  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  className: PropTypes.string
+};
+
+TextArea.defaultProps = {
+  rows: DEFAULT_ROWS,
+  classBlock: DEFAULT_CLASS,
+  classModifiers: []
+};
+
+TextArea.displayName = 'TextArea';
+
+export default TextArea;

--- a/src/TextArea/TextArea.jsx
+++ b/src/TextArea/TextArea.jsx
@@ -1,6 +1,6 @@
 // Global imports
-import React from 'react';
 import PropTypes from 'prop-types';
+import React, { useEffect, useState } from 'react';
 
 // Local imports
 import Readonly from '../Readonly';
@@ -12,7 +12,7 @@ export const DEFAULT_CLASS = 'govuk-textarea';
 const TextArea = ({
   id,
   fieldId,
-  rows,
+  rows: _rows,
   disabled,
   error,
   readonly,
@@ -21,6 +21,11 @@ const TextArea = ({
   className,
   ...attrs
 }) => {
+  const [rows, setRows] = useState(DEFAULT_ROWS);
+  useEffect(() => {
+    const rowsNumber = parseInt(_rows, 10);
+    setRows(isNaN(rowsNumber) ? DEFAULT_ROWS : rowsNumber);
+  }, [_rows, setRows]);
   const classModifiers = [...toArray(_classModifiers), error ? 'error' : undefined ];
   const classes = classBuilder(classBlock, classModifiers, className);
   if (readonly) {
@@ -45,7 +50,7 @@ const TextArea = ({
 TextArea.propTypes = {
   id: PropTypes.string.isRequired,
   fieldId: PropTypes.string.isRequired,
-  rows: PropTypes.number.isRequired,
+  rows: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   disabled: PropTypes.bool,
   error: PropTypes.string,
   readonly: PropTypes.bool,

--- a/src/TextArea/TextArea.scss
+++ b/src/TextArea/TextArea.scss
@@ -1,0 +1,1 @@
+@import "node_modules/govuk-frontend/govuk/components/textarea/textarea";

--- a/src/TextArea/TextArea.stories.mdx
+++ b/src/TextArea/TextArea.stories.mdx
@@ -1,0 +1,122 @@
+<!-- Global imports -->
+import { useState } from 'react';
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+
+<!-- Local imports -->
+import Details from '../Details';
+import TextArea from './TextArea';
+import Link from '../Link';
+
+<Meta title="Text area" id="D-TextArea" component={ TextArea } />
+
+# Text input
+
+<Canvas>
+  <Story name="Default">
+    <TextArea id="input" fieldId="input" />
+  </Story>
+</Canvas>
+
+<Details summary="Properties" className="no-indent">
+  <ArgsTable of={ TextArea } />
+</Details>
+
+# Variants
+## Disabled
+
+A disabled text input.
+
+<Canvas>
+  <Story name="Disabled">
+    <TextArea id="disabledInput" fieldId="disabledInput" disabled={true} />
+  </Story>
+</Canvas>
+
+## Error
+
+A text input in an error state.
+
+<Canvas>
+  <Story name="Error">
+    <TextArea id="errorInput" fieldId="errorInput" error="This is an error" />
+  </Story>
+</Canvas>
+
+## Readonly
+
+A readonly "input".
+
+<Canvas>
+  <Story name="Readonly">
+    <TextArea id="readonlyInput" fieldId="readonlyInput" value="This is readonly text." readonly />
+  </Story>
+</Canvas>
+
+## Track changes
+
+A text input with an `onChange` handler that tracks changes as you type.
+
+<Canvas>
+  <Story name="Track changes">
+    {() => {
+      const [value, setValue] = useState({});
+      const [changes, setChanges] = useState([]);
+      const onChange = ({ target }) => {
+        setValue(prev => {
+          const next = { ...prev, [target.name]: target.value };
+          setChanges(prevChanges => {
+            return [...prevChanges, { ts: Date.now(), value: next }];
+          });
+          return next;
+        });
+      };
+      const fieldId = 'textInput';
+      const options = {
+        id: 'textInput',
+        fieldId,
+        value: value[fieldId] || '',
+        onChange
+      };
+      return (
+        <>
+          <TextArea {...options} />
+          {changes && 
+            <>
+              <br /><br />
+              <Details summary="Change series" className="no-indent">
+                <ol>
+                  {changes && changes.map(change => (
+                    <li key={change.ts}>{JSON.stringify(change.value)}</li>
+                  ))}
+                </ol>
+              </Details>
+            </>
+          }
+        </>
+      );
+    }}
+  </Story>
+</Canvas>
+
+
+## When to use this component
+Use the text input component when you need to let users enter text that’s no longer than a single line, such as their name or phone number.
+
+## When not to use this component
+Do not use the text input component if you need to let users enter longer answers that might span multiple lines. In this case, you should use the textarea component.
+
+## How it works
+All text inputs must have visible labels; placeholder text is not an acceptable replacement for a label as it vanishes when users start typing.
+
+Labels should be aligned above the text input they refer to. They should be short, direct and written in sentence case. Do not use colons at the end of labels.
+
+If you’re asking just <Link href="https://design-system.service.gov.uk/patterns/question-pages/#start-by-asking-one-question-per-page">one question per page</Link> 
+as recommended, you can set the contents of the `<label>` as the page heading. This is good practice as it means that users of screen readers will only hear the contents once.
+
+Read more about <Link href="https://design-system.service.gov.uk/get-started/labels-legends-headings/">why and how to set legends as headings</Link>.
+
+<Canvas>
+  <Story name="Default2">
+    <TextArea id="input" fieldId="input" />
+  </Story>
+</Canvas>

--- a/src/TextArea/TextArea.stories.mdx
+++ b/src/TextArea/TextArea.stories.mdx
@@ -3,17 +3,26 @@ import { useState } from 'react';
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 
 <!-- Local imports -->
+import Alert from '../Alert';
 import Details from '../Details';
+import FormGroup from '../FormGroup';
+import Heading from '../Heading';
 import TextArea from './TextArea';
 import Link from '../Link';
 
 <Meta title="Text area" id="D-TextArea" component={ TextArea } />
 
-# Text input
+<Heading size="xl" caption="Components">Text area</Heading>
 
 <Canvas>
   <Story name="Default">
-    <TextArea id="input" fieldId="input" />
+    <FormGroup
+      id="default"
+      label={<Heading size="l">Can you provide more detail?</Heading>}
+      hint="Do not include personal or financial information, like your National Insurance number or credit card details."
+    >
+      <TextArea id="default" fieldId="default" />
+    </FormGroup>
   </Story>
 </Canvas>
 
@@ -21,102 +30,162 @@ import Link from '../Link';
   <ArgsTable of={ TextArea } />
 </Details>
 
-# Variants
-## Disabled
+# When to use this component
+Use the textarea component when you need to let users enter an amount of text that's longer than a single line.
 
-A disabled text input.
+# When not to use this component
+Users can find open-ended questions difficult to answer.
+It might be better to break up one complex question into a series of simple ones,
+for example where users can select from options using <Link href="./?path=/docs/d-radios--radios">radios</Link>.
+
+### If you need to ask an open question
+Do not use the textarea component if you need to let users enter shorter answers no longer than a single line,
+such as a phone number or name. In this case, you should use the <Link href="./?path=/docs/d-textinput--default-story">text input</Link>
+component.
+
+# How it works
+You must label textareas. Placeholder text is not a suitable substitute for a label,
+as it disappears when users click inside the textarea.
+
+Labels must be aligned above the textarea they refer to. They should be short,
+direct and written in sentence case. Do not use colons at the end of labels.
+
+<Alert heading="Labels and hints">
+Everything to do with labels and hints is handled by the <Link href="./?path=/docs/internal-form-group--default-story">form group</Link> component,
+rather than by the text area component itself.
+</Alert>
 
 <Canvas>
-  <Story name="Disabled">
-    <TextArea id="disabledInput" fieldId="disabledInput" disabled={true} />
+  <Story name="More detail">
+    <FormGroup
+      id="more-detail"
+      label={<Heading size="l">Can you provide more detail?</Heading>}
+      hint="Do not include personal or financial information, like your National Insurance number or credit card details."
+    >
+      <TextArea id="more-detail" fieldId="more-detail" />
+    </FormGroup>
   </Story>
 </Canvas>
 
-## Error
-
-A text input in an error state.
+## Use appropriately-sized textareas
+Make the height of a textarea proportional to the amount of text you expect users to enter.
+You can set the height of a textarea by by specifying the `rows` attribute. If you do not
+specify the `rows` attribute, it will default to 5 rows.
 
 <Canvas>
-  <Story name="Error">
-    <TextArea id="errorInput" fieldId="errorInput" error="This is an error" />
+  <Story name="More rows">
+    <FormGroup
+      id="more-rows"
+      label={<Heading size="l">Can you provide more detail?</Heading>}
+      hint="Do not include personal or financial information, like your National Insurance number or credit card details."
+    >
+      <TextArea id="more-rows" fieldId="more-rows" rows="8" />
+    </FormGroup>
   </Story>
 </Canvas>
 
-## Readonly
+### Do not disable copy and paste
+Users will often need to copy and paste information into a textarea, so do not stop them from doing this.
 
-A readonly "input".
+### If you're asking more than one question on the page
+If you're asking more than one question on the page, do not set the contents of the `<label>`
+as the page heading.
+Read more about <Link target="multiple-questions" href="https://design-system.service.gov.uk/patterns/question-pages/#asking-multiple-questions-on-a-page">asking multiple questions on question pages</Link>.
+
+<Canvas>
+  <Story name="Multiple questions">
+    <FormGroup
+      id="multiple-questions"
+      label="Can you provide more detail?"
+      required={true}
+    >
+      <TextArea id="multiple-questions" fieldId="multiple-questions" />
+    </FormGroup>
+  </Story>
+</Canvas>
+
+### Limiting the number of characters
+If there's a good reason to limit the number of characters users can enter, you can use
+the <Link target="character-count" href="https://design-system.service.gov.uk/components/character-count/">character count</Link> component.
+
+### Error messages
+Error messages should be styled like this:
+
+<Canvas>
+  <Story name="Error messages">
+    <FormGroup
+      id="error"
+      label={<Heading size="l">Can you provide more detail?</Heading>}
+      hint="Do not include personal or financial information, like your National Insurance number or credit card details."
+      required={true}
+      error="Enter more detail"
+    >
+      <TextArea id="error" fieldId="error" error="Enter more detail" />
+    </FormGroup>
+  </Story>
+</Canvas>
+
+Make sure errors follow the guidance in error message and have specific error messages for specific error states.
+
+### If the input is empty
+Say 'Enter [whatever it is]'.<br />
+For example, 'Enter summary'.
+
+### If the input is too long
+Say '[whatever it is] must be [number] characters or fewer'.<br />
+For example, 'Summary must be 400 characters or fewer'.
+
+### If the input is too short
+Say '[whatever it is] must be [number] characters or more'.<br />
+For example, 'Summary must be 10 characters or more'.
+
+### If the input is too long or too short
+Say '[whatever it is] must be between [number] and [number] characters'.<br />
+For example, 'Summary must be between 10 and 400 characters'.
+
+### If the input uses characters that are not allowed and you know what the characters are
+Say '[whatever it is] must not include [characters]'.<br />
+For example, 'Summary must not include è and £'.
+
+### If the input uses characters that are not allowed and you do not know what the characters are
+Say '[whatever it is] must only include [list of allowed characters]'.<br />
+For example, 'Summary must only include letters a to z, hyphens, spaces and apostrophes.
+
+# Other variants
+
+### Readonly
+Use a readonly "textarea" when you want to show the user what they have entered but do not
+want them to be able to edit the contents in that circumstance - for example,
+on a <Link target="check-answers" href="https://design-system.service.gov.uk/patterns/check-answers/">Check your answers</Link> page.
+
+<Alert heading="Compared to disabled components">
+You should prefer readonly variants over disabled ones, except where your user research specifically
+shows that disabled components aid user comprehension in your particular usage.
+</Alert>
 
 <Canvas>
   <Story name="Readonly">
-    <TextArea id="readonlyInput" fieldId="readonlyInput" value="This is readonly text." readonly />
+    <FormGroup
+      id="readonly"
+      label={<Heading size="l">Can you provide more detail?</Heading>}
+    >
+      <TextArea id="readonly" fieldId="readonly" readonly={true} value="Here is some content entered before it was made readonly." />
+    </FormGroup>
   </Story>
 </Canvas>
 
-## Track changes
-
-A text input with an `onChange` handler that tracks changes as you type.
-
-<Canvas>
-  <Story name="Track changes">
-    {() => {
-      const [value, setValue] = useState({});
-      const [changes, setChanges] = useState([]);
-      const onChange = ({ target }) => {
-        setValue(prev => {
-          const next = { ...prev, [target.name]: target.value };
-          setChanges(prevChanges => {
-            return [...prevChanges, { ts: Date.now(), value: next }];
-          });
-          return next;
-        });
-      };
-      const fieldId = 'textInput';
-      const options = {
-        id: 'textInput',
-        fieldId,
-        value: value[fieldId] || '',
-        onChange
-      };
-      return (
-        <>
-          <TextArea {...options} />
-          {changes && 
-            <>
-              <br /><br />
-              <Details summary="Change series" className="no-indent">
-                <ol>
-                  {changes && changes.map(change => (
-                    <li key={change.ts}>{JSON.stringify(change.value)}</li>
-                  ))}
-                </ol>
-              </Details>
-            </>
-          }
-        </>
-      );
-    }}
-  </Story>
-</Canvas>
-
-
-## When to use this component
-Use the text input component when you need to let users enter text that’s no longer than a single line, such as their name or phone number.
-
-## When not to use this component
-Do not use the text input component if you need to let users enter longer answers that might span multiple lines. In this case, you should use the textarea component.
-
-## How it works
-All text inputs must have visible labels; placeholder text is not an acceptable replacement for a label as it vanishes when users start typing.
-
-Labels should be aligned above the text input they refer to. They should be short, direct and written in sentence case. Do not use colons at the end of labels.
-
-If you’re asking just <Link href="https://design-system.service.gov.uk/patterns/question-pages/#start-by-asking-one-question-per-page">one question per page</Link> 
-as recommended, you can set the contents of the `<label>` as the page heading. This is good practice as it means that users of screen readers will only hear the contents once.
-
-Read more about <Link href="https://design-system.service.gov.uk/get-started/labels-legends-headings/">why and how to set legends as headings</Link>.
+### Disabled
+Use a disabled textarea only where your user research specifically shows that doing so aids user comprehension
+in your particular usage - otherwise, use the readonly variant.
 
 <Canvas>
-  <Story name="Default2">
-    <TextArea id="input" fieldId="input" />
+  <Story name="Disabled">
+    <FormGroup
+      id="disabled"
+      label={<Heading size="l">Can you provide more detail?</Heading>}
+      hint="Do not include personal or financial information, like your National Insurance number or credit card details."
+    >
+      <TextArea id="disabled" fieldId="disabled" disabled={true} value="Here is some content entered before it was disabled." />
+    </FormGroup>
   </Story>
 </Canvas>

--- a/src/TextArea/TextArea.test.js
+++ b/src/TextArea/TextArea.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, getByTestId, render } from '@testing-library/react';
-import TextArea, { DEFAULT_CLASS } from './TextArea';
+import TextArea, { DEFAULT_CLASS, DEFAULT_ROWS } from './TextArea';
 import { DEFAULT_CLASS as DEFAULT_READONLY_CLASS } from '../Readonly';
 
 describe('TextArea', () => {
@@ -21,6 +21,40 @@ describe('TextArea', () => {
     expect(textarea.name).toEqual(TEXT_AREA_FIELD_ID);
     expect(textarea.value).toEqual('');
     expect(textarea.getAttribute('disabled')).toBeNull();
+    expect(textarea.getAttribute('rows')).toEqual(`${DEFAULT_ROWS}`); // String vs number
+  });
+
+  it('should accept a specified number of rows', async () => {
+    const TEXT_AREA_ID = 'textarea';
+    const TEXT_AREA_FIELD_ID = 'textareaFieldId';
+    const ROWS = 23;
+    const { container } = render(
+      <TextArea data-testid={TEXT_AREA_ID} id={TEXT_AREA_ID} fieldId={TEXT_AREA_FIELD_ID} rows={ROWS} />
+    );
+    const textarea = checkSetup(container, TEXT_AREA_ID);
+    expect(textarea.getAttribute('rows')).toEqual(`${ROWS}`); // String vs number
+  });
+
+  it('should accept a specified number of rows as a string', async () => {
+    const TEXT_AREA_ID = 'textarea';
+    const TEXT_AREA_FIELD_ID = 'textareaFieldId';
+    const ROWS = "12";
+    const { container } = render(
+      <TextArea data-testid={TEXT_AREA_ID} id={TEXT_AREA_ID} fieldId={TEXT_AREA_FIELD_ID} rows={ROWS} />
+    );
+    const textarea = checkSetup(container, TEXT_AREA_ID);
+    expect(textarea.getAttribute('rows')).toEqual(ROWS);
+  });
+
+  it('should accept an invalid row value and revert to the default', async () => {
+    const TEXT_AREA_ID = 'textarea';
+    const TEXT_AREA_FIELD_ID = 'textareaFieldId';
+    const ROWS = "this is not a number";
+    const { container } = render(
+      <TextArea data-testid={TEXT_AREA_ID} id={TEXT_AREA_ID} fieldId={TEXT_AREA_FIELD_ID} rows={ROWS} />
+    );
+    const textarea = checkSetup(container, TEXT_AREA_ID);
+    expect(textarea.getAttribute('rows')).toEqual(`${DEFAULT_ROWS}`); // String vs number
   });
 
   it('should accept the disabled flag', async () => {

--- a/src/TextArea/TextArea.test.js
+++ b/src/TextArea/TextArea.test.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import { fireEvent, getByTestId, render } from '@testing-library/react';
+import TextArea, { DEFAULT_CLASS } from './TextArea';
+import { DEFAULT_CLASS as DEFAULT_READONLY_CLASS } from '../Readonly';
+
+describe('TextArea', () => {
+
+  const checkSetup = (container, testId) => {
+    const textarea = getByTestId(container, testId);
+    expect(textarea.classList).toContain(DEFAULT_CLASS);
+    return textarea;
+  };
+
+  it('should be appropriately set up with id and name', async () => {
+    const TEXT_AREA_ID = 'textarea';
+    const TEXT_AREA_FIELD_ID = 'textareaFieldId';
+    const { container } = render(
+      <TextArea data-testid={TEXT_AREA_ID} id={TEXT_AREA_ID} fieldId={TEXT_AREA_FIELD_ID} />
+    );
+    const textarea = checkSetup(container, TEXT_AREA_ID);
+    expect(textarea.name).toEqual(TEXT_AREA_FIELD_ID);
+    expect(textarea.value).toEqual('');
+    expect(textarea.getAttribute('disabled')).toBeNull();
+  });
+
+  it('should accept the disabled flag', async () => {
+    const TEXT_AREA_ID = 'textarea';
+    const TEXT_AREA_FIELD_ID = 'textareaFieldId';
+    const { container } = render(
+      <TextArea data-testid={TEXT_AREA_ID} id={TEXT_AREA_ID} fieldId={TEXT_AREA_FIELD_ID} disabled={true} />
+    );
+    const textarea = checkSetup(container, TEXT_AREA_ID);
+    expect(textarea.getAttribute('disabled')).not.toBeNull();
+  });
+
+  it('should accept the readonly flag', async () => {
+    const TEXT_AREA_ID = 'textarea';
+    const TEXT_AREA_FIELD_ID = 'textareaFieldId';
+    const { container } = render(
+      <TextArea data-testid={TEXT_AREA_ID} id={TEXT_AREA_ID} fieldId={TEXT_AREA_FIELD_ID} readonly={true} />
+    );
+    const textarea = getByTestId(container, TEXT_AREA_ID);
+    expect(textarea.tagName).toEqual('DIV');
+    expect(textarea.classList).toContain(DEFAULT_READONLY_CLASS);
+  });
+
+  it('should be in an error state when the error is set', async () => {
+    const TEXT_AREA_ID = 'textarea';
+    const TEXT_AREA_FIELD_ID = 'textareaFieldId';
+    const ERROR = 'This is in error';
+    const { container } = render(
+      <TextArea data-testid={TEXT_AREA_ID} id={TEXT_AREA_ID} fieldId={TEXT_AREA_FIELD_ID} error={ERROR} />
+    );
+    const textarea = checkSetup(container, TEXT_AREA_ID);
+    expect(textarea.classList).toContain(`${DEFAULT_CLASS}--error`);
+    expect(textarea.value).toEqual('');
+  });
+
+  it('should not be in an error state when the error is an empty string', async () => {
+    const TEXT_AREA_ID = 'textarea';
+    const TEXT_AREA_FIELD_ID = 'textareaFieldId';
+    const ERROR = '';
+    const { container } = render(
+      <TextArea data-testid={TEXT_AREA_ID} id={TEXT_AREA_ID} fieldId={TEXT_AREA_FIELD_ID} error={ERROR} />
+    );
+    const textarea = checkSetup(container, TEXT_AREA_ID);
+    expect(textarea.classList).not.toContain(`${DEFAULT_CLASS}--error`);
+    expect(textarea.value).toEqual('');
+  });
+
+  it('should set the value and onChange on the underlying textarea appropriately', async () => {
+    const TEXT_AREA_ID = 'textarea';
+    const TEXT_AREA_FIELD_ID = 'textareaFieldId';
+    const VALUE = 'This is the value';
+    let onChangeCalls = 0;
+    const ON_CHANGE = () => {
+      onChangeCalls++;
+    };
+    const { container } = render(
+      <TextArea
+        data-testid={TEXT_AREA_ID} id={TEXT_AREA_ID} fieldId={TEXT_AREA_FIELD_ID}
+        value={VALUE} onChange={ON_CHANGE} />
+    );
+    const textarea = checkSetup(container, TEXT_AREA_ID);
+    expect(textarea.value).toEqual(VALUE);
+    expect(onChangeCalls).toEqual(0);
+    const EVENT = { target: { name: TEXT_AREA_FIELD_ID, value: `${VALUE}.` } };
+    fireEvent.change(textarea, EVENT);
+    expect(onChangeCalls).toEqual(1);
+  });
+
+});

--- a/src/TextArea/index.js
+++ b/src/TextArea/index.js
@@ -1,0 +1,3 @@
+import TextArea from './TextArea';
+
+export default TextArea;

--- a/src/assets/scss/storybook.css
+++ b/src/assets/scss/storybook.css
@@ -108,3 +108,9 @@ div[role="main"] > div {
 #docs-root .sbdocs.sbdocs-wrapper {
   padding-top: 1.75rem;
 }
+
+#docs-root .sbdocs-p {
+  font-size: 1.1875rem;
+  line-height: 1.31579;
+  margin-bottom: 20px;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import Panel from './Panel';
 import Radios, { Radio } from './Radios';
 import Readonly from './Readonly';
 import Tag from './Tag';
+import TextArea from './TextArea';
 import TextInput from './TextInput';
 import Utils from './utils/Utils';
 import VisuallyHidden from './VisuallyHidden';
@@ -50,6 +51,7 @@ export {
   SmallHeading,
   StartButton,
   Tag,
+  TextArea,
   TextInput,
   Utils,
   VisuallyHidden,


### PR DESCRIPTION
### Description
Added a `TextArea` component (initially as part of a demo). The Storybook stories are aligned with those on GDS (with adjustments and additions where appropriate) and the unit tests are quite extensive and sensible (100% coverage, catching all the edge cases I could think of).

https://support.cop.homeoffice.gov.uk/browse/COP-10048

### To test
Essentially covered by accompanying unit tests and Storybook stories.