### PR TITLE
EAB-105 Make required validation work for Date component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/DateInput/DateInput.jsx
+++ b/src/DateInput/DateInput.jsx
@@ -31,7 +31,9 @@ const DateInput = ({
   });
 
   const handleChange = (event) => {
-    setDate((prev) => ({ ...prev, [event.target.name]: event.target.value }));
+    const name = event.target.name;
+    const value = event.target.value;
+    setDate((prev) => ({ ...prev, [name]: value }));
   };
 
   useEffect(() => {

--- a/src/DateInput/DateInput.jsx
+++ b/src/DateInput/DateInput.jsx
@@ -6,33 +6,10 @@ import React, { useEffect, useState } from 'react';
 import FormGroup from '../FormGroup/FormGroup';
 import Readonly from '../Readonly';
 import TextInput from '../TextInput';
-import { classBuilder } from '../utils/Utils';
+import { classBuilder, getMonthName } from '../utils/Utils';
 
 // Styles
 import './DateInput.scss';
-
-// Consider moving this array and function beneath to /utils.
-const MONTH_NAMES = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December',
-];
-const getMonthName = (month) => {
-  const monthIndex = parseInt(month, 10) - 1;
-  if (monthIndex > -1 && monthIndex < 12) {
-    return MONTH_NAMES[monthIndex];
-  }
-  return '';
-};
 
 export const DEFAULT_CLASS = 'govuk-date-input';
 const DateInput = ({
@@ -73,7 +50,8 @@ const DateInput = ({
 
   useEffect(() => {
     if (typeof onChange === 'function' && date) {
-      const newValue = `${date.day}-${date.month}-${date.year}`;
+      let newValue = `${date.day}-${date.month}-${date.year}`;
+      newValue = (newValue === '--') ? '' : newValue;
       if (newValue !== value) {
         onChange({ target: { name: fieldId, value: newValue }});
       }
@@ -95,7 +73,7 @@ const DateInput = ({
   return (
     <div className={DEFAULT_CLASS} id={id} {...attrs}>
       {DATE_PARTS.map(part => (
-        <FormGroup id={`${id}-${part.id}`} label={part.label} required classBlock={classes('item')}>
+        <FormGroup id={`${id}-${part.id}`} label={part.label} required classBlock={classes('item')} key={`${id}-${part.id}`}>
           <TextInput
             id={`${id}-${part.id}`}
             fieldId={`${fieldId}-${part.id}`}
@@ -119,11 +97,7 @@ DateInput.propTypes = {
   classBlock: PropTypes.string,
   classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   className: PropTypes.string,
-  error: PropTypes.shape({
-    day: PropTypes.bool,
-    month: PropTypes.bool,
-    year: PropTypes.bool,
-  }),
+  error: PropTypes.any,
   value: PropTypes.string,
   onChange: PropTypes.func,
   readonly: PropTypes.bool,

--- a/src/DateInput/DateInput.jsx
+++ b/src/DateInput/DateInput.jsx
@@ -1,5 +1,5 @@
 // Global Imports
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 // Local imports
@@ -24,6 +24,31 @@ const DateInput = ({
 }) => {
   const classes = classBuilder(classBlock, classModifiers, className);
 
+  const [date, setDate] = useState({
+    [`${id}-day`]: value?.day ? value.day : '',
+    [`${id}-month`]: value?.month ? value.month : '',
+    [`${id}-year`]: value?.year ? value.year : '',
+  });
+
+  const handleChange = (event) => {
+    setDate((prev) => ({ ...prev, [event.target.name]: event.target.value }));
+  };
+
+  useEffect(() => {
+    if (typeof onChange === 'function') {
+      let singleVal = '';
+      if (date[`${id}-day`] && date[`${id}-month`] && date[`${id}-year`]) {
+        singleVal = `${date[`${id}-day`]}-${date[`${id}-month`]}-${date[`${id}-year`]}`;
+      }
+      onChange({
+        target: {
+          name: id,
+          value: singleVal,
+        },
+      });
+    }
+  }, [date]);
+
   const convertMonth = (monthNum) => {
     return [
       'January',
@@ -42,9 +67,10 @@ const DateInput = ({
   };
 
   if (readonly) {
+    const dateParts = value.split('-');
     return (
       <Readonly id={id} classModifiers={classModifiers} className={className} {...attrs}>
-        {value?.day} {value?.month ? convertMonth(value.month) : ''} {value?.year}
+        {dateParts[0]} {convertMonth(dateParts[1])} {dateParts[2]}
       </Readonly>
     );
   }
@@ -58,8 +84,8 @@ const DateInput = ({
         <TextInput
           id={`${id}-day`}
           fieldId={`${fieldId}-day`}
-          value={value?.day}
-          onChange={onChange}
+          value={`${date[`${id}-day`]}`}
+          onChange={handleChange}
           pattern='[0-9]*'
           inputMode='numeric'
           error={error?.day ? 'error' : ''}
@@ -74,8 +100,8 @@ const DateInput = ({
         <TextInput
           id={`${id}-month`}
           fieldId={`${fieldId}-month`}
-          value={value?.month}
-          onChange={onChange}
+          value={`${date[`${id}-month`]}`}
+          onChange={handleChange}
           pattern='[0-9]*'
           inputMode='numeric'
           error={error?.month ? 'error' : ''}
@@ -90,8 +116,8 @@ const DateInput = ({
         <TextInput
           id={`${id}-year`}
           fieldId={`${fieldId}-year`}
-          value={value?.year}
-          onChange={onChange}
+          value={`${date[`${id}-year`]}`}
+          onChange={handleChange}
           pattern='[0-9]*'
           inputMode='numeric'
           error={error?.year ? 'error' : ''}
@@ -114,11 +140,7 @@ DateInput.propTypes = {
     month: PropTypes.bool,
     year: PropTypes.bool,
   }),
-  value: PropTypes.shape({
-    day: PropTypes.number,
-    month: PropTypes.number,
-    year: PropTypes.number,
-  }),
+  value: PropTypes.any,
   onChange: PropTypes.func,
   readonly: PropTypes.bool,
 };

--- a/src/DateInput/DateInput.stories.mdx
+++ b/src/DateInput/DateInput.stories.mdx
@@ -9,9 +9,9 @@ import Details from '../Details';
 import FormGroup from '../FormGroup';
 import DateInput from './DateInput';
 
-<Meta id='D-DateInput' title='DateInput' component={DateInput} />
+<Meta id='D-DateInput' title='Date input' component={DateInput} />
 
-# DateInput
+# Date input
 
 <Canvas withToolbar>
   <Story name='DateInput'>
@@ -90,7 +90,7 @@ If you're asking more than one question on the page, do not set the contents of 
           <DateInput
             id='dateinputreadonly'
             fieldId='dateinputreadonly'
-            value={{ day: 6, month: 3, year: 2022 }}
+            value={'6-3-2022'}
             readonly
           />
         </FormGroup>
@@ -107,21 +107,10 @@ If you're highlighting the whole date, style all the fields like this:
   <Story name='DateInputError'>
     {() => {
       const ID='dateinputerror';
-      const [value, setValue] = useState({
-        day: 6, month: 3, year: 2076
-      });      
+      const [value, setValue] = useState('6-3-2076');
       const onChange = (event) => {
-        const id = event.target.id;
-        if(id === `${ID}-day`){
-          setValue((prev) => ({...prev, day: event.target.value}))
-        }
-        if(id === `${ID}-month`){
-          setValue((prev) => ({...prev, month: event.target.value}))
-        }
-        if(id === `${ID}-year`){
-          setValue((prev) => ({...prev, year: event.target.value}))
-        }
-      }
+        setValue(event.target.value);
+      };
       return (
         <FormGroup
           id='dateinput'
@@ -138,6 +127,7 @@ If you're highlighting the whole date, style all the fields like this:
             error={{ year: true, month: true, day: true }}
             onChange={(event) => onChange(event)}
           />
+          <div>Currently entered date: {value}</div>
         </FormGroup>
       );
     }}
@@ -150,20 +140,9 @@ If you're highlighting just one field - either the day, month or year - only sty
   <Story name='DateInputMissingYear'>
     {() => {
       const ID='dateinputmissingyear';
-      const [value, setValue] = useState({
-        day: 6, month: 3
-      });      
+      const [value, setValue] = useState('6-3-');      
       const onChange = (event) => {
-        const id = event.target.id;
-        if(id === `${ID}-day`){
-          setValue((prev) => ({...prev, day: event.target.value}))
-        }
-        if(id === `${ID}-month`){
-          setValue((prev) => ({...prev, month: event.target.value}))
-        }
-        if(id === `${ID}-year`){
-          setValue((prev) => ({...prev, year: event.target.value}))
-        }
+        setValue(event.value);
       }
       return (
         <FormGroup

--- a/src/DateInput/DateInput.test.js
+++ b/src/DateInput/DateInput.test.js
@@ -96,9 +96,9 @@ describe('DateInput', () => {
     const ID = 'dateinput';
     const FIELD_ID = 'dateinputId';
 
-    let onChangeCalls = 0;
-    const ON_CHANGE = () => {
-      onChangeCalls++;
+    const onChangeCalls = [];
+    const ON_CHANGE = (event) => {
+      onChangeCalls.push(event);
     };
 
     const { container } = render(
@@ -107,7 +107,7 @@ describe('DateInput', () => {
         id={ID}
         fieldId={FIELD_ID}
         error={{ year: true, month: true, day: true }}
-        value={{ day: 6, month: 3, year: 2076 }}
+        value={'6-3-2076'}
         onChange={ON_CHANGE}
       />
     );
@@ -117,20 +117,26 @@ describe('DateInput', () => {
     //day
     const dayInput = wrapper.childNodes[0].childNodes[1];
     expect(dayInput.value).toEqual('6');
-    fireEvent.change(dayInput, { target: { name: FIELD_ID, value: 12 } });
-    expect(onChangeCalls).toEqual(2);
+    fireEvent.change(dayInput, { target: { name: `${FIELD_ID}-day`, value: 12 } });
+    expect(onChangeCalls.length).toEqual(1);
+    expect(onChangeCalls[0]).toMatchObject({
+      target: {
+        name: FIELD_ID,
+        value: '12-3-2076'
+      }
+    });
 
     //month
     const monthInput = wrapper.childNodes[1].childNodes[1];
     expect(monthInput.value).toEqual('3');
     fireEvent.change(monthInput, { target: { value: 2 } });
-    expect(onChangeCalls).toEqual(3);
+    expect(onChangeCalls.length).toEqual(2);
 
     //year
     const yearInput = wrapper.childNodes[2].childNodes[1];
     expect(yearInput.value).toEqual('2076');
     fireEvent.change(yearInput, { target: { value: 1999 } });
-    expect(onChangeCalls).toEqual(4);
+    expect(onChangeCalls.length).toEqual(3);
   });
 
   it('should appropriately set up the necessary components when read only', async () => {
@@ -141,7 +147,7 @@ describe('DateInput', () => {
         data-testid={ID}
         id={ID}
         fieldId={FIELD_ID}
-        value='12-12-2012'
+        value={'12-12-2012'}
         readonly
       />
     );
@@ -167,5 +173,23 @@ describe('DateInput', () => {
     expect(input.tagName).toEqual('DIV');
     expect(input.classList).toContain(DEFAULT_READONLY_CLASS);
     expect(input.textContent).toEqual('6 July 2076');
+  });
+
+  it('should handle an invalid month in readonly mode', async () => {
+    const ID = 'dateinput';
+    const FIELD_ID = 'dateinputId';
+    const { container } = render(
+      <DateInput
+        data-testid={ID}
+        id={ID}
+        fieldId={FIELD_ID}
+        value={'6-13-2076'}
+        readonly
+      />
+    );
+    const input = checkSetup(container, ID);
+    expect(input.tagName).toEqual('DIV');
+    expect(input.classList).toContain(DEFAULT_READONLY_CLASS);
+    expect(input.textContent).toEqual('6  2076');
   });
 });

--- a/src/DateInput/DateInput.test.js
+++ b/src/DateInput/DateInput.test.js
@@ -118,19 +118,19 @@ describe('DateInput', () => {
     const dayInput = wrapper.childNodes[0].childNodes[1];
     expect(dayInput.value).toEqual('6');
     fireEvent.change(dayInput, { target: { name: FIELD_ID, value: 12 } });
-    expect(onChangeCalls).toEqual(1);
+    expect(onChangeCalls).toEqual(2);
 
     //month
     const monthInput = wrapper.childNodes[1].childNodes[1];
     expect(monthInput.value).toEqual('3');
     fireEvent.change(monthInput, { target: { value: 2 } });
-    expect(onChangeCalls).toEqual(2);
+    expect(onChangeCalls).toEqual(3);
 
     //year
     const yearInput = wrapper.childNodes[2].childNodes[1];
     expect(yearInput.value).toEqual('2076');
     fireEvent.change(yearInput, { target: { value: 1999 } });
-    expect(onChangeCalls).toEqual(3);
+    expect(onChangeCalls).toEqual(4);
   });
 
   it('should appropriately set up the necessary components when read only', async () => {
@@ -141,26 +141,25 @@ describe('DateInput', () => {
         data-testid={ID}
         id={ID}
         fieldId={FIELD_ID}
-        value={{ day: 6, month: 3, year: 2076 }}
+        value='12-12-2012'
         readonly
       />
     );
     const input = checkSetup(container, ID);
     expect(input.tagName).toEqual('DIV');
     expect(input.classList).toContain(DEFAULT_READONLY_CLASS);
-    expect(input.textContent).toEqual('6 March 2076');
+    expect(input.textContent).toEqual('12 December 2012');
   });
 
   it('should convert month number values to the word equivalent', async () => {
     const ID = 'dateinput';
     const FIELD_ID = 'dateinputId';
-    let MONTH = 7;
     const { container } = render(
       <DateInput
         data-testid={ID}
         id={ID}
         fieldId={FIELD_ID}
-        value={{ day: 6, month: MONTH, year: 2076 }}
+        value={'6-7-2076'}
         readonly
       />
     );

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -65,21 +65,21 @@ export const classBuilder = (block, blockModifiers, blockExtra) => {
  * @param {*} month
  * @returns The name of the month corresponding to the number given.
  */
+ const MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
 export const getMonthName = (month) => {
-  const MONTH_NAMES = [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December',
-  ];
   const monthIndex = parseInt(month, 10) - 1;
   if (monthIndex > -1 && monthIndex < 12) {
     return MONTH_NAMES[monthIndex];

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -60,8 +60,36 @@ export const classBuilder = (block, blockModifiers, blockExtra) => {
   };
 };
 
+/**
+ * Should be used to convert from a number between 1 and 12 to the corresponding months name.
+ * @param {*} month
+ * @returns The name of the month corresponding to the number given.
+ */
+export const getMonthName = (month) => {
+  const MONTH_NAMES = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
+  const monthIndex = parseInt(month, 10) - 1;
+  if (monthIndex > -1 && monthIndex < 12) {
+    return MONTH_NAMES[monthIndex];
+  }
+  return '';
+};
+
 const Utils = {
   classBuilder,
+  getMonthName,
   interpolateString,
   toArray
 };


### PR DESCRIPTION
The previous implementation of the Date component passed up values for each part of the date (day, month, year) to Form Renderer separately with property names in the format "ComponentID-Day", "ComponentID-Month" etc. The validators in Form Renderer then looked for a value to be assigned the property "ComponentID" and found none and validation didn't work properly. 

This change captures changes to each of the Date fields and consolidates them into a single string format "dd-mm-yyyy" before passing on that new information to Form Renderer with property name "ComponentID" so the validators can find the value and function properly. If any of the fields are empty then an empty string is returned instead meaning that if someone enters a day and a year leaving the month blank they will still be prompted to complete the date. 