### PR TITLE
Replace GDS blue with Home Office blue

### DIFF
--- a/.storybook/govuk-theme.js
+++ b/.storybook/govuk-theme.js
@@ -5,7 +5,7 @@ const GovUKTheme = create({
   base: 'light',
 
   colorPrimary: '#0b0c0c',
-  colorSecondary: '#1d70b8',
+  colorSecondary: '#005ea5',
 
   // UI
   appBg: 'white',
@@ -22,7 +22,7 @@ const GovUKTheme = create({
   textInverseColor: 'rgba(255,255,255,0.9)',
 
   // Toolbar default and active colors
-  barTextColor: '#1d70b8',
+  barTextColor: '#005ea5',
   barSelectedColor: '#0b0c0c',
   // barBg: 'white',
 

--- a/src/Details/Details.scss
+++ b/src/Details/Details.scss
@@ -8,6 +8,7 @@ $govuk-font-family: 'Roboto', arial, sans-serif;
 
   &__summary {
     @extend .govuk-details__summary;
+    color: #005ea5;
   }
   &__text {
     @extend .govuk-details__text;

--- a/src/Link/Link.scss
+++ b/src/Link/Link.scss
@@ -1,6 +1,11 @@
 @import "node_modules/govuk-frontend/govuk/_base";
 @import "node_modules/govuk-frontend/govuk/core/_links";
 
-a {
-  @extend .govuk-link
+a, a:link {
+  @extend .govuk-link;
+  color: #005ea5;
+}
+
+.govuk-link, .govuk-link:link {
+  color: #005ea5;
 }


### PR DESCRIPTION
### Description
Replacing the GDS blue with the Home Office blue. This is needed for the contrast ratio - the Home Office blue is slightly darker than the GDS one.

### To test
There should be no accessibility contrast issues with the `Link` or `Details` components, nor with any anchor tags, using an accessibility tool like Wave or Axe.