### PR TITLE
Fix autocomplete story

### DIFF
--- a/src/Autocomplete/Autocomplete.stories.mdx
+++ b/src/Autocomplete/Autocomplete.stories.mdx
@@ -4,7 +4,7 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 
 <!-- Local imports -->
 import Autocomplete, { RefDataAutocomplete } from './Autocomplete';
-import { Countries, CountriesAsRefData, CountriesByName } from './Countries.stories.test';
+import { Countries, CountriesAsRefData, CountriesByName } from './Countries-sb';
 import Details from '../Details';
 import Label from '../Label';
 import { interpolateString } from '../utils/Utils';

--- a/src/Autocomplete/Countries-sb.js
+++ b/src/Autocomplete/Countries-sb.js
@@ -22,7 +22,3 @@ const setupCountries = () => {
 };
 
 setupCountries();
-
-it('should be a function', () => {
-  expect(typeof setupCountries).toEqual('function');
-});

--- a/src/Autocomplete/Countries-sb.test.js
+++ b/src/Autocomplete/Countries-sb.test.js
@@ -1,0 +1,9 @@
+import { Countries, CountriesAsRefData, CountriesByName } from './Countries-sb';
+
+describe('Countries-sb', () => {
+  it('should export arrays appropriately', () => {
+    expect(Array.isArray(Countries)).toBeTruthy();
+    expect(Array.isArray(CountriesAsRefData)).toBeTruthy();
+    expect(Array.isArray(CountriesByName)).toBeTruthy();
+  });
+});

--- a/src/FormGroup/FormGroup.stories.mdx
+++ b/src/FormGroup/FormGroup.stories.mdx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Canvas, Meta, Props, Story } from '@storybook/addon-docs';
 import Autocomplete from '../Autocomplete/Autocomplete';
-import { CountriesByName } from '../Autocomplete/Countries.stories.test';
+import { CountriesByName } from '../Autocomplete/Countries-sb';
 import Details from '../Details';
 import FormGroup from './FormGroup';
 import Tag from '../Tag';


### PR DESCRIPTION
### Description
The Storybook story for the `Autocomplete` would _sometimes_ work fine and other times not. It seems to be related to trying to import a .test.js file in those stories so I've simply renamed the file for it and added a test to not drop coverage.

### To test
There should be a link for the `Autocomplete` component in the left-hand side and the page should render fine when it is clicked on. If there's no link or there's a problem with the page, this fails.