### PR TITLE
Tag alpha components

### DIFF
--- a/src/Checkboxes/Checkboxes.stories.mdx
+++ b/src/Checkboxes/Checkboxes.stories.mdx
@@ -7,11 +7,14 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 
 import Details from '../Details';
 import FormGroup from '../FormGroup';
+import Tag from '../Tag';
 import Checkboxes from './Checkboxes';
 
 <Meta id='D-Checkboxes' title='Checkboxes' component={Checkboxes} />
 
 # Checkboxes
+
+<p><Tag text="Alpha" /></p>
 
 <Canvas withToolbar>
   <Story name='Checkboxes'>

--- a/src/DateInput/DateInput.stories.mdx
+++ b/src/DateInput/DateInput.stories.mdx
@@ -7,11 +7,14 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 
 import Details from '../Details';
 import FormGroup from '../FormGroup';
+import Tag from '../Tag';
 import DateInput from './DateInput';
 
 <Meta id='D-DateInput' title='Date input' component={DateInput} />
 
 # Date input
+
+<p><Tag text="Alpha" /></p>
 
 <Canvas withToolbar>
   <Story name='DateInput'>

--- a/src/ErrorMessage/ErrorMessage.stories.mdx
+++ b/src/ErrorMessage/ErrorMessage.stories.mdx
@@ -3,7 +3,7 @@ import { Canvas, Meta, Props, Story } from '@storybook/addon-docs';
 import Details from '../Details';
 import ErrorMessage from './ErrorMessage';
 
-<Meta title="ErrorMessage" id="D-ErrorMessage" component={ ErrorMessage } />
+<Meta title="Error message" id="D-ErrorMessage" component={ ErrorMessage } />
 
 # Error message
 

--- a/src/InsetText/InsetText.stories.mdx
+++ b/src/InsetText/InsetText.stories.mdx
@@ -6,7 +6,7 @@ import Details from '../Details';
 import InsetText from './InsetText';
 import Link from '../Link';
 
-<Meta title="InsetText" id="D-InsetText" component={ InsetText } />
+<Meta title="Inset text" id="D-InsetText" component={ InsetText } />
 
 # Inset text
 

--- a/src/TextArea/TextArea.stories.mdx
+++ b/src/TextArea/TextArea.stories.mdx
@@ -7,12 +7,15 @@ import Alert from '../Alert';
 import Details from '../Details';
 import FormGroup from '../FormGroup';
 import Heading from '../Heading';
-import TextArea from './TextArea';
 import Link from '../Link';
+import Tag from '../Tag';
+import TextArea from './TextArea';
 
 <Meta title="Text area" id="D-TextArea" component={ TextArea } />
 
-<Heading size="xl" caption="Components">Text area</Heading>
+# Text area
+
+<p><Tag text="Alpha" /></p>
 
 <Canvas>
   <Story name="Default">

--- a/src/TextInput/TextInput.stories.mdx
+++ b/src/TextInput/TextInput.stories.mdx
@@ -4,13 +4,16 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 
 <!-- Local imports -->
 import Details from '../Details';
-import TextInput from './TextInput';
 import Link from '../Link';
 import FormGroup from '../FormGroup';
+import Tag from '../Tag';
+import TextInput from './TextInput';
 
 <Meta title="Text input" id="D-TextInput" component={ TextInput } />
 
 # Text input
+
+<p><Tag text="Alpha" /></p>
 
 <Canvas>
   <Story name="Default">

--- a/src/VisuallyHidden/VisuallyHidden.stories.mdx
+++ b/src/VisuallyHidden/VisuallyHidden.stories.mdx
@@ -5,7 +5,7 @@ import VisuallyHidden from './VisuallyHidden';
 import Tag from '../Tag';
 import './VisuallyHidden.stories.scss';
 
-<Meta title="Internal/VisuallyHidden" id="D-VisuallyHidden" component={ VisuallyHidden } />
+<Meta title="Internal/Visually hidden" id="D-VisuallyHidden" component={ VisuallyHidden } />
 
 # Visually hidden
 


### PR DESCRIPTION
### Description
Components that haven't yet been checked by UX and the test team should be given an `Alpha` tag in the corresponding Storybook story. I've added them for `Checkboxes`, `DateInput`, `TextArea`, and the updated `TextInput` that haven't yet gone through the sign-off process.

Also sorted out some of the names in the menu so that they're sentence case rather than Pascal case.

### To test
The `Checkboxes`, `DateInput`, `TextArea`, and `TextInput` components should each display an `Alpha` tag beneath the page title in Storybook.
