### PR TITLE
COP-10269: Use hods-button class instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "1.1.0-alpha",
+  "version": "1.1.1-alpha",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/Button/Button.jsx
+++ b/src/Button/Button.jsx
@@ -4,7 +4,7 @@ import Link from '../Link';
 import { classBuilder, toArray } from '../utils/Utils';
 import './Button.scss';
 
-export const DEFAULT_CLASS = 'govuk-button';
+export const DEFAULT_CLASS = 'hods-button';
 export const START_BUTTON_LABEL = 'Start now';
 
 const isAnchor = (href) => {

--- a/src/Button/Button.scss
+++ b/src/Button/Button.scss
@@ -1,2 +1,54 @@
 @import "node_modules/govuk-frontend/govuk/_base";
+
+$govuk-button-colour: #00823b;
+$govuk-button-hover-colour: govuk-shade($govuk-button-colour, 20%);
+$govuk-button-shadow-colour: govuk-shade($govuk-button-colour, 60%);
+
+$govuk-secondary-button-colour: #f8f8f8;
+$govuk-secondary-button-hover-colour: govuk-shade($govuk-secondary-button-colour, 10%);
+$govuk-secondary-button-shadow-colour: govuk-colour('black');
+$govuk-secondary-button-border-colour: govuk-colour('black');
+
+$govuk-warning-button-colour: govuk-colour("red");
+$govuk-warning-button-hover-colour: govuk-shade($govuk-warning-button-colour, 20%);
+$govuk-warning-button-shadow-colour: govuk-shade($govuk-warning-button-colour, 60%);
+
 @import "node_modules/govuk-frontend/govuk/components/button";
+
+.hods-button {
+  @extend .govuk-button;
+  padding: 8px 16px;
+  border: none;
+  margin-right: 30px;
+  background: $govuk-button-colour;
+  box-shadow: 0px 2px 0px $govuk-button-shadow-colour;
+  &:hover {
+    background-color: $govuk-button-hover-colour;
+  }
+
+  &--warning {
+    @extend .govuk-button--warning;
+    background: $govuk-warning-button-colour;
+    box-shadow: 0px 2px 0px $govuk-warning-button-shadow-colour;
+    &:hover {
+      background-color: $govuk-warning-button-hover-colour;
+    }
+  }
+  &--start {
+    @extend .govuk-button--start;
+  }
+  &__start-icon {
+    @extend .govuk-button__start-icon;
+  }
+  &--secondary {
+    @extend .govuk-button--secondary;
+    padding: 8px 15px;
+    border: 1px solid $govuk-secondary-button-border-colour;
+    box-sizing: border-box;
+    background: $govuk-secondary-button-colour;
+    box-shadow: 0px 1px 0px $govuk-secondary-button-shadow-colour;
+    &:hover {
+      background-color: $govuk-secondary-button-hover-colour;
+    }
+  }
+}

--- a/src/Button/Button.stories.mdx
+++ b/src/Button/Button.stories.mdx
@@ -1,12 +1,17 @@
-import { Meta, Props, Story, Canvas } from '@storybook/addon-docs';
-import Button, { StartButton } from './Button';
+<!-- Global imports -->
+import { Canvas, Meta, Props, Story } from '@storybook/addon-docs';
+
+<!-- Local imports -->
 import ButtonGroup from '../ButtonGroup';
 import Details from '../Details';
 import Link from '../Link';
+import Tag from '../Tag';
+import Button, { StartButton } from './Button';
 
 <Meta title="Button" id="D-Button" component={ Button } />
 
 # Button
+<p><Tag text="Alpha" />&nbsp;<Tag text="New styling" /></p>
 
 <Canvas withToolbar>
   <Story name="Default">

--- a/src/ButtonGroup/ButtonGroup.jsx
+++ b/src/ButtonGroup/ButtonGroup.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { classBuilder } from '../utils/Utils';
 import './ButtonGroup.scss';
 
-export const DEFAULT_CLASS = 'govuk-button-group';
+export const DEFAULT_CLASS = 'hods-button-group';
 export const ButtonGroup = ({
   children,
   classBlock,

--- a/src/ButtonGroup/ButtonGroup.scss
+++ b/src/ButtonGroup/ButtonGroup.scss
@@ -1,2 +1,30 @@
 @import "node_modules/govuk-frontend/govuk/_base";
 @import "govuk-frontend/govuk/objects/_button-group";
+
+.hods-button-group {
+  @extend .govuk-button-group;
+  $horizontal-gap: govuk-spacing(3);
+  $vertical-gap: govuk-spacing(3);
+
+  // These need to be kept in sync with the button component's styles
+  $button-padding: govuk-spacing(2);
+  $button-shadow-size: $govuk-border-width-form-element;
+
+  $link-spacing: govuk-spacing(1);
+
+  .hods-button {
+    margin-bottom: $vertical-gap + $button-shadow-size;
+  }
+
+  @include govuk-media-query($from: tablet) {
+    .hods-button, .hods-link {
+      margin-right: $horizontal-gap * 2;
+    }
+    .hods-link {
+      text-align: left;
+    }
+    :last-child {
+      margin-right: 0;
+    }
+  }
+}

--- a/src/ButtonGroup/ButtonGroup.stories.mdx
+++ b/src/ButtonGroup/ButtonGroup.stories.mdx
@@ -1,13 +1,21 @@
-import { Meta, Props, Story, Canvas } from '@storybook/addon-docs';
+<!-- Global imports -->
+import { Canvas, Meta, Props, Story } from '@storybook/addon-docs';
+
+<!-- Local imports -->
 import Button from '../Button';
 import Details from '../Details';
 import Link from '../Link';
+import Tag from '../Tag';
 import ButtonGroup from './ButtonGroup';
+
+<!-- Styles -->
 import './ButtonGroup.stories.scss';
 
 <Meta title="Internal/Button group" id="D-ButtonGroup" component={ ButtonGroup } />
 
 # Button group
+
+<p><Tag text="Alpha" />&nbsp;<Tag text="New styling" /></p>
 
 A component for grouping buttons and links on a single line.
 


### PR DESCRIPTION
### Description
Introduced new `hods-button` and `hods-button-group` classes for the `Button` and `ButtonGroup` components, respectively. They each extend the corresponding `govuk` classes and override some of the colours, borders, and shadows, according to the Figma designs.

There was no `'warning'` button that I could find so that remains the same as the GDS one.

https://support.cop.homeoffice.gov.uk/browse/COP-10269

### To test
The button colours should now be aligned to those in the Figma document linked to in the JIRA ticket. Also make sure the layouts haven't changed and that the buttons are appropriately lined up with the same height, etc.