### PR TITLE
COP-10358: Fix button margins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/Button/Button.scss
+++ b/src/Button/Button.scss
@@ -19,7 +19,6 @@ $govuk-warning-button-shadow-colour: govuk-shade($govuk-warning-button-colour, 6
   @extend .govuk-button;
   padding: 8px 16px;
   border: none;
-  margin-right: 30px;
   background: $govuk-button-colour;
   box-shadow: 0px 2px 0px $govuk-button-shadow-colour;
   &:hover {

--- a/src/ButtonGroup/ButtonGroup.scss
+++ b/src/ButtonGroup/ButtonGroup.scss
@@ -13,18 +13,19 @@
   $link-spacing: govuk-spacing(1);
 
   .hods-button {
+    margin-right: 0;
     margin-bottom: $vertical-gap + $button-shadow-size;
   }
 
   @include govuk-media-query($from: tablet) {
-    .hods-button, .hods-link {
+    .hods-button, .hods-link, .govuk-button, .govuk-link {
       margin-right: $horizontal-gap * 2;
+      &:last-child {
+        margin-right: 0;
+      }
     }
     .hods-link {
       text-align: left;
-    }
-    :last-child {
-      margin-right: 0;
     }
   }
 }


### PR DESCRIPTION
### Description
The margin for buttons in the mobile view is such that the buttons end up getting pushed off to the left. This needs to be sorted or else it looks odd in the mobile view.

https://support.cop.homeoffice.gov.uk/browse/COP-10358

### To test
The spacing between buttons should look correct on the desktop and tablet views. When viewing on a mobile, they should now also look correct and not offset to the left, which is how they _were_ appearing.