### PR TITLE
EAB-174 Add date validation capability to DateInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/DateInput/DateInput.jsx
+++ b/src/DateInput/DateInput.jsx
@@ -19,6 +19,7 @@ const DateInput = ({
   classModifiers,
   className,
   error,
+  propsinerror,
   value,
   onChange,
   readonly,
@@ -81,7 +82,7 @@ const DateInput = ({
             onChange={handleChange}
             pattern='[0-9]*'
             inputMode='numeric'
-            error={error && error[part.id] ? 'error' : ''}
+            error={propsinerror && propsinerror[part.id] ? 'error' : ''}
             className={classes('input')}
             classModifiers={`width-${part.width}`}
           />
@@ -98,6 +99,7 @@ DateInput.propTypes = {
   classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   className: PropTypes.string,
   error: PropTypes.any,
+  propsinerror: PropTypes.any,
   value: PropTypes.string,
   onChange: PropTypes.func,
   readonly: PropTypes.bool,

--- a/src/DateInput/DateInput.test.js
+++ b/src/DateInput/DateInput.test.js
@@ -70,7 +70,7 @@ describe('DateInput', () => {
         data-testid={ID}
         id={ID}
         fieldId={FIELD_ID}
-        error={{ year: true, month: true, day: true }}
+        propsinerror={{ year: true, month: true, day: true }}
       />
     );
     const wrapper = checkSetup(container, ID);
@@ -106,7 +106,7 @@ describe('DateInput', () => {
         data-testid={ID}
         id={ID}
         fieldId={FIELD_ID}
-        error={{ year: true, month: true, day: true }}
+        propsinerror={{ year: true, month: true, day: true }}
         value={'6-3-2076'}
         onChange={ON_CHANGE}
       />


### PR DESCRIPTION
In order to pass information from Form-Renderer to the DateInput component about which boxes should be highlighted with error formatting a new prop is required. This PR adds that prop. 

The PR to add the date validation and set the error formatting can be seen here https://github.com/UKHomeOffice/cop-react-form-renderer/pull/65 