### PR TITLE
added a dark-grey colour in the tag component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/Tag/Tag.scss
+++ b/src/Tag/Tag.scss
@@ -15,6 +15,9 @@ $govuk-font-family: 'Roboto', arial, sans-serif;
   &::first-letter {
     text-transform: uppercase;
   }
+  &--dark-grey{
+    background: #5C6367;
+  }
 }
 
 @include hods-tag-colours('inactive'); // Deprecated.

--- a/src/Tag/Tag.stories.mdx
+++ b/src/Tag/Tag.stories.mdx
@@ -44,6 +44,10 @@ If you need more tag colours, you can use the following tints.
       </thead>
       <tbody className="govuk-table__body">
         <tr className="govuk-table__row">
+          <td className="govuk-table__col"><code>dark-grey</code></td>
+          <td className="govuk-table__col"><Tag classModifiers="dark-grey">not started</Tag></td>
+        </tr>
+        <tr className="govuk-table__row">
           <td className="govuk-table__col"><code>grey</code></td>
           <td className="govuk-table__col"><Tag classModifiers="grey">inactive</Tag></td>
         </tr>


### PR DESCRIPTION
Description
Added a `dark-grey` colour to the `Tag` component for increased contrast. Added a row in the Tag story table with an example.
https://support.cop.homeoffice.gov.uk/browse/COP-10589