### PR TITLE
COP-10567: Add FileUpload component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "1.3.0-alpha",
+  "version": "1.3.0",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "1.2.2",
+  "version": "1.3.0-alpha",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/FileUpload/FileUpload.jsx
+++ b/src/FileUpload/FileUpload.jsx
@@ -1,0 +1,167 @@
+// Global imports
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+// Local imports
+import Button from '../Button';
+import Readonly from '../Readonly';
+import { classBuilder, toArray } from '../utils/Utils';
+
+// Styles
+import './FileUpload.scss';
+
+export const DEFAULT_CLASS = 'hods-file-upload';
+const FileUpload = ({
+  id,
+  fieldId,
+  disabled,
+  error,
+  readonly,
+  value: _value,
+  onChange,
+  classBlock,
+  classModifiers: _classModifiers,
+  className,
+  ...attrs
+}) => {
+  const [value, setValue] = useState({});
+  const [thumb, setThumb] = useState(null);
+  const [icon, setIcon] = useState(null);
+
+  useEffect(() => {
+    if (_value) {
+      setValue(_value);
+    } else {
+      setValue(undefined);
+    }
+  }, [_value, setValue]);
+
+  useEffect(() => {
+    let newThumb = null;
+    let newIcon = null;
+    if (value) {
+      const { url, file, type, extension } = value;
+      if (type) {
+        if (type.indexOf('image/') === 0) {
+          if (url) {
+            newThumb = url;
+          } else if (file) {
+            newThumb = URL.createObjectURL(file);
+          }
+        } else {
+          newIcon = extension;
+        }
+      }
+    }
+    setThumb(newThumb);
+    setIcon(newIcon);
+  }, [value, setThumb, setIcon]);
+
+  const err = error ? 'error' : undefined;
+  const dis = disabled ? 'disabled' : undefined;
+  const classModifiers = [...toArray(_classModifiers), err, dis];
+  const classes = classBuilder(classBlock, classModifiers, className);
+
+  const dispatchChange = (changeValue) => {
+    if (typeof onChange === 'function') {
+      onChange({ target: { name: fieldId, value: changeValue } }); 
+    }
+  };
+
+  const onFileSelected = (e) => {
+    const file = e.target.files[0];
+    const extension = file.name.split('.').pop();
+    const newValue = {
+      name: file.name,
+      extension,
+      type: file.type,
+      file,
+      url: ''
+    };
+    setValue(newValue);
+    dispatchChange(newValue);
+  };
+
+  const onRemoveFile = () => {
+    setValue(undefined);
+    dispatchChange(undefined);
+  };
+
+  if (readonly) {
+    return (
+      <Readonly id={id} classModifiers={classModifiers} className={className} {...attrs}>
+        {value?.name && (
+          <>
+            {value.name}
+            {thumb && <img className={classes('thumb')} src={thumb} alt={value.name} />}
+            {icon && <div className={`${classes('icon')} document-icon-${icon}`}></div>}
+          </>
+        )}
+      </Readonly>
+    );
+  }
+
+  return (
+    <div className={classes()} disabled={disabled}>
+      <input
+        {...attrs}
+        value={''}
+        onChange={onFileSelected}
+        disabled={disabled}
+        id={`${id}-select`}
+        name={`${fieldId}-select`}
+        type="file"
+        className={classes('select')}
+      />
+      <label htmlFor={`${fieldId}-select`} className={classes('label')}>
+        <span className={classes('label-button')}>Choose file</span>
+        {value?.name ? (
+          <span className={classes('label-filename')}>{value.name}</span>
+        ) : 'No file chosen'
+        }
+      </label>
+      {value?.name && (
+        <>
+          {thumb && <img className={classes('thumb')} src={thumb} alt={value.name} />}
+          {icon && <div className={`${classes('icon')} document-icon-${icon}`}></div>}
+          <Button
+            id={`${id}-remove`}
+            classModifiers="secondary"
+            className={classes('remove')}
+            onClick={() => onRemoveFile()}
+          >
+            Remove
+          </Button>
+        </>
+      )}
+    </div>
+  );
+};
+
+FileUpload.propTypes = {
+  id: PropTypes.string.isRequired,
+  fieldId: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
+  error: PropTypes.string,
+  readonly: PropTypes.bool,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({
+      url: PropTypes.string,
+      name: PropTypes.string,
+      type: PropTypes.string,
+      file: PropTypes.any
+    })
+  ]),
+  onChange: PropTypes.func,
+  classBlock: PropTypes.string,
+  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  className: PropTypes.string
+};
+
+FileUpload.defaultProps = {
+  classBlock: DEFAULT_CLASS,
+  classModifiers: []
+};
+
+export default FileUpload;

--- a/src/FileUpload/FileUpload.jsx
+++ b/src/FileUpload/FileUpload.jsx
@@ -144,15 +144,13 @@ FileUpload.propTypes = {
   disabled: PropTypes.bool,
   error: PropTypes.string,
   readonly: PropTypes.bool,
-  value: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.shape({
-      url: PropTypes.string,
-      name: PropTypes.string,
-      type: PropTypes.string,
-      file: PropTypes.any
-    })
-  ]),
+  value: PropTypes.shape({
+    name: PropTypes.string,
+    extension: PropTypes.string,
+    type: PropTypes.string,
+    file: PropTypes.any,
+    url: PropTypes.string,
+  }),
   onChange: PropTypes.func,
   classBlock: PropTypes.string,
   classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),

--- a/src/FileUpload/FileUpload.scss
+++ b/src/FileUpload/FileUpload.scss
@@ -1,0 +1,72 @@
+@import "node_modules/govuk-frontend/govuk/_base";
+
+.hods-file-upload {
+  position: relative;
+  width: 100%;
+  max-width: 400px;
+  &__select {
+    opacity: 0;
+    z-index: -1;
+    position: absolute;
+    &:focus + label {
+      border: solid 4px $govuk-input-border-colour;
+      outline: 3px solid $govuk-focus-colour;
+      margin: -3px;
+      padding: 6px 1px;
+    }
+  }
+  &__label {
+    display: inline-block;
+    box-sizing: border-box;
+    @include govuk-font($size: 19);
+    color: $govuk-text-colour;
+    padding: 7px 2px;
+    white-space: nowrap;
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &-button {
+      border: solid 1px $govuk-input-border-colour;
+      border-radius: 4px;
+      background-color: #efefef;
+      padding: 0.25rem;
+      margin-right: 3px;
+      &:hover {
+        background-color: #e5e5e5;
+        cursor: pointer;
+      }
+    }
+  }
+  &__remove {
+    margin-top: 0.25rem;
+    margin-bottom: 0;
+  }
+
+  &--disabled {
+    .hods-file-upload__label {
+      pointer-events: none;
+      color: #0b0c0c99;
+      &-button {
+        color: #b1b4b6;
+        border-color: #b1b4b699;
+        background: #e0e0e080;
+      }
+    }
+  }
+
+  &--error {
+    .hods-file-upload__label {
+      border: 2px solid $govuk-error-colour;
+    }
+  }
+
+  &__thumb, &__icon {
+    display: block;
+    margin-top: 0.5rem;
+  }
+  &__thumb {
+    width: 50%;
+    border: solid 1px $govuk-input-border-colour;
+  }
+}

--- a/src/FileUpload/FileUpload.scss
+++ b/src/FileUpload/FileUpload.scss
@@ -12,7 +12,7 @@
       border: solid 4px $govuk-input-border-colour;
       outline: 3px solid $govuk-focus-colour;
       margin: -3px;
-      padding: 6px 1px;
+      padding: 6px 2px;
     }
   }
   &__label {
@@ -20,7 +20,7 @@
     box-sizing: border-box;
     @include govuk-font($size: 19);
     color: $govuk-text-colour;
-    padding: 7px 2px;
+    padding: 7px 3px;
     white-space: nowrap;
     width: 100%;
     overflow: hidden;
@@ -58,6 +58,7 @@
   &--error {
     .hods-file-upload__label {
       border: 2px solid $govuk-error-colour;
+      padding: 5px 1px;
     }
   }
 

--- a/src/FileUpload/FileUpload.stories.mdx
+++ b/src/FileUpload/FileUpload.stories.mdx
@@ -1,0 +1,119 @@
+<!-- Global imports -->
+import { useState } from 'react';
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+
+<!-- Local imports -->
+import Details from '../Details';
+import Tag from '../Tag';
+import FileUpload from './FileUpload';
+
+<Meta title="File upload" id="D-FileUpload" component={ FileUpload } />
+
+# File upload
+
+<p><Tag text="Alpha" /></p>
+
+<Canvas>
+  <Story name="Default">
+    <FileUpload id="fileUpload" fieldId="fileUpload" />
+  </Story>
+</Canvas>
+
+<Details summary="Properties" className="no-indent">
+  <ArgsTable of={ FileUpload } />
+</Details>
+
+# Variants
+## Disabled
+
+A disabled file upload.
+
+<Canvas>
+  <Story name="Disabled">
+    <FileUpload id="disabled" fieldId="disabled" disabled />
+  </Story>
+</Canvas>
+
+## Error
+
+A file upload in an error state.
+
+<Canvas>
+  <Story name="Error">
+    <FileUpload id="error" fieldId="error" error="This is an error" />
+  </Story>
+</Canvas>
+
+## Readonly
+
+A readonly "file upload".
+
+<Canvas>
+  <Story name="Readonly">
+    <FileUpload
+      id="readonlyInput"
+      fieldId="readonlyInput"
+      value={{
+        name: 'govuk-crest.png',
+        type: 'image/png',
+        url: 'images/govuk-crest.png'
+      }}
+      readonly
+    />
+  </Story>
+</Canvas>
+
+## Track changes
+
+A file upload with an `onChange` handler that captures a selected or removed file.
+
+<Canvas>
+  <Story name="Track changes">
+    {() => {
+      const [value, setValue] = useState({});
+      const [changes, setChanges] = useState([]);
+      const onChange = ({ target }) => {
+        setValue(prev => {
+          const next = { ...prev, [target.name]: target.value };
+          setChanges(prevChanges => {
+            return [...prevChanges, { ts: Date.now(), value: next }];
+          });
+          return next;
+        });
+      };
+      const fieldId = 'fileUpload';
+      const options = {
+        id: fieldId,
+        fieldId,
+        value: value[fieldId] || '',
+        onChange
+      };
+      return (
+        <>
+          <FileUpload {...options} />
+          {changes && 
+            <>
+              <br /><br />
+              <Details summary="Change series" className="no-indent">
+                <ol>
+                  {changes && changes.map(change => (
+                    <li key={change.ts}>{JSON.stringify(change.value)}</li>
+                  ))}
+                </ol>
+              </Details>
+            </>
+          }
+        </>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## When to use this component
+You should only ask users to upload something if it's critical to the delivery of your service.
+
+<Canvas>
+  <Story name="Default2">
+    <FileUpload id="fileUpload" fieldId="fileUpload" />
+  </Story>
+</Canvas>

--- a/src/FileUpload/FileUpload.test.js
+++ b/src/FileUpload/FileUpload.test.js
@@ -1,0 +1,219 @@
+// Global imports
+import { fireEvent, getByTestId, render } from '@testing-library/react';
+import user from '@testing-library/user-event';
+import React from 'react';
+
+// Local imports
+import { DEFAULT_CLASS as DEFAULT_READONLY_CLASS } from '../Readonly';
+import FileUpload, { DEFAULT_CLASS } from './FileUpload';
+
+describe('FileUpload', () => {
+
+  beforeEach(() => {
+    global.URL.createObjectURL = jest.fn();
+  });
+
+  const checkSetup = (container, testId) => {
+    const wrapper = container.firstChild;
+    expect(wrapper.classList).toContain(DEFAULT_CLASS);
+    const input = getByTestId(container, testId);
+    if (input) {
+      expect(input.classList).toContain(`${DEFAULT_CLASS}__select`);
+    }
+    return { wrapper, input };
+  };
+
+  it('should be appropriately set up with id and name', async () => {
+    const INPUT_ID = 'input';
+    const INPUT_FIELD_ID = 'inputFieldId';
+    const { container } = render(
+      <FileUpload data-testid={INPUT_ID} id={INPUT_ID} fieldId={INPUT_FIELD_ID} />
+    );
+    const { input } = checkSetup(container, INPUT_ID);
+    expect(input.name).toEqual(`${INPUT_FIELD_ID}-select`);
+    expect(input.type).toEqual('file');
+    expect(input.value).toEqual('');
+    expect(input.getAttribute('disabled')).toBeNull();
+  });
+
+  it('should accept the disabled flag', async () => {
+    const INPUT_ID = 'input';
+    const INPUT_FIELD_ID = 'inputFieldId';
+    const { container } = render(
+      <FileUpload data-testid={INPUT_ID} id={INPUT_ID} fieldId={INPUT_FIELD_ID} disabled={true} />
+    );
+    const { wrapper, input } = checkSetup(container, INPUT_ID);
+    expect(wrapper.classList).toContain(`${DEFAULT_CLASS}--disabled`);
+    expect(input.getAttribute('disabled')).not.toBeNull();
+  });
+
+  it('should accept the readonly flag for an image', async () => {
+    const INPUT_ID = 'input';
+    const INPUT_FIELD_ID = 'inputFieldId';
+    const VALUE = {
+      name: 'test-image.jpg',
+      extension: 'jpg',
+      type: 'image/jpg',
+      url: 'http://test.image.com/image.jpg'
+    };
+    const { container } = render(
+      <FileUpload data-testid={INPUT_ID} id={INPUT_ID} fieldId={INPUT_FIELD_ID} value={VALUE} readonly />
+    );
+    const readonly = getByTestId(container, INPUT_ID);
+    expect(readonly.tagName).toEqual('DIV');
+    expect(readonly.classList).toContain(DEFAULT_READONLY_CLASS);
+    const [name, thumb] = readonly.childNodes;
+    expect(name.textContent).toEqual(VALUE.name);
+    expect(thumb.tagName).toEqual('IMG');
+    expect(thumb.src).toEqual(VALUE.url);
+  });
+
+  it('should accept the readonly flag for a non-image', async () => {
+    const INPUT_ID = 'input';
+    const INPUT_FIELD_ID = 'inputFieldId';
+    const VALUE = {
+      name: 'test-file.pdf',
+      extension: 'pdf',
+      type: 'application/pdf',
+      url: 'http://test.file.com/file.pdf'
+    };
+    const { container } = render(
+      <FileUpload data-testid={INPUT_ID} id={INPUT_ID} fieldId={INPUT_FIELD_ID} value={VALUE} readonly />
+    );
+    const readonly = getByTestId(container, INPUT_ID);
+    expect(readonly.tagName).toEqual('DIV');
+    expect(readonly.classList).toContain(DEFAULT_READONLY_CLASS);
+    const [name, icon] = readonly.childNodes;
+    expect(name.textContent).toEqual(VALUE.name);
+    expect(icon.tagName).toEqual('DIV');
+    expect(icon.classList).toContain('document-icon-pdf');
+  });
+
+  it('should be in an error state when the error is set', async () => {
+    const INPUT_ID = 'input';
+    const INPUT_FIELD_ID = 'inputFieldId';
+    const ERROR = 'This is in error';
+    const { container } = render(
+      <FileUpload data-testid={INPUT_ID} id={INPUT_ID} fieldId={INPUT_FIELD_ID} error={ERROR} />
+    );
+    const { wrapper } = checkSetup(container, INPUT_ID);
+    expect(wrapper.classList).toContain(`${DEFAULT_CLASS}--error`);
+  });
+
+  it('should not be in an error state when the error is an empty string', async () => {
+    const INPUT_ID = 'input';
+    const INPUT_FIELD_ID = 'inputFieldId';
+    const ERROR = '';
+    const { container } = render(
+      <FileUpload data-testid={INPUT_ID} id={INPUT_ID} fieldId={INPUT_FIELD_ID} error={ERROR} />
+    );
+    const { wrapper } = checkSetup(container, INPUT_ID);
+    expect(wrapper.classList).not.toContain(`${DEFAULT_CLASS}--error`);
+  });
+
+  it('should fire the onChange event when a file is uploaded', async () => {
+    const INPUT_ID = 'input';
+    const INPUT_FIELD_ID = 'inputFieldId';
+    const str = JSON.stringify({ alpha: 'bravo' });
+    const blob = new Blob([str]);
+    const FILE = new File([blob], 'test.json', { type: 'application/JSON', });
+    const ON_CHANGE_CALLS = [];
+    const ON_CHANGE = (e) => {
+      ON_CHANGE_CALLS.push(e);
+    };
+    const { container } = render(
+      <FileUpload data-testid={INPUT_ID} id={INPUT_ID} fieldId={INPUT_FIELD_ID} onChange={ON_CHANGE} />
+    );
+    const { wrapper, input } = checkSetup(container, INPUT_ID);
+    expect(wrapper.childNodes.length).toEqual(2); // input + label
+    expect(ON_CHANGE_CALLS.length).toEqual(0);
+    user.upload(input, FILE);
+    expect(ON_CHANGE_CALLS.length).toEqual(1);
+    expect(input.files.length).toEqual(1);
+    expect(wrapper.childNodes.length).toEqual(4); // input + label + icon + remove button
+    const [ , , icon, remove ] = wrapper.childNodes;
+    expect(icon.tagName).toEqual('DIV');
+    expect(icon.classList).toContain('document-icon-json');
+    expect(remove.tagName).toEqual('BUTTON');
+    expect(remove.textContent).toEqual('Remove');
+  });
+
+  it('should display a thumbnail from a url appropriately', async () => {
+    const INPUT_ID = 'input';
+    const INPUT_FIELD_ID = 'inputFieldId';
+    const VALUE = {
+      name: 'test-image.jpg',
+      extension: 'jpg',
+      type: 'image/jpg',
+      url: 'http://test.image.com/image.jpg'
+    };
+    const { container } = render(
+      <FileUpload data-testid={INPUT_ID} id={INPUT_ID} fieldId={INPUT_FIELD_ID} value={VALUE} />
+    );
+    const { wrapper } = checkSetup(container, INPUT_ID);
+    const [ , label, thumb ] = wrapper.childNodes;
+    expect(label.textContent).toContain(VALUE.name);
+    expect(thumb.tagName).toEqual('IMG');
+    expect(thumb.src).toEqual(VALUE.url);
+  });
+
+  it('should handle removal of a file appropriately', async () => {
+    const INPUT_ID = 'input';
+    const INPUT_FIELD_ID = 'inputFieldId';
+    const VALUE = {
+      name: 'test-image.jpg',
+      extension: 'jpg',
+      type: 'image/jpg',
+      url: 'http://test.image.com/image.jpg'
+    };
+    const ON_CHANGE_CALLS = [];
+    const ON_CHANGE = (e) => {
+      ON_CHANGE_CALLS.push(e);
+    };
+    const { container } = render(
+      <FileUpload data-testid={INPUT_ID} id={INPUT_ID} fieldId={INPUT_FIELD_ID} value={VALUE} onChange={ON_CHANGE} />
+    );
+    const { wrapper } = checkSetup(container, INPUT_ID);
+    const [ , label, thumb, remove ] = wrapper.childNodes;
+    expect(label.textContent).toContain(VALUE.name);
+    expect(thumb.tagName).toEqual('IMG');
+    expect(thumb.src).toEqual(VALUE.url);
+
+    // Now click on the Remove button.
+    fireEvent.click(remove, {});
+    expect(wrapper.childNodes.length).toEqual(2); // Removed the thumb and remove button.
+
+    // The onChange handler should also have fired.
+    expect(ON_CHANGE_CALLS.length).toEqual(1);
+    expect(ON_CHANGE_CALLS[0]).toMatchObject({
+      target: {
+        name: INPUT_FIELD_ID,
+        value: undefined
+      }
+    });
+  });
+
+  it('should handle removal of a file without an onChange handler specified', async () => {
+    const INPUT_ID = 'input';
+    const INPUT_FIELD_ID = 'inputFieldId';
+    const VALUE = {
+      name: 'test-image.jpg',
+      extension: 'jpg',
+      type: 'image/jpg',
+      url: 'http://test.image.com/image.jpg'
+    };
+    const { container } = render(
+      <FileUpload data-testid={INPUT_ID} id={INPUT_ID} fieldId={INPUT_FIELD_ID} value={VALUE} />
+    );
+    const { wrapper } = checkSetup(container, INPUT_ID);
+    const [ , label, thumb, remove ] = wrapper.childNodes;
+    expect(label.textContent).toContain(VALUE.name);
+    expect(thumb.tagName).toEqual('IMG');
+    expect(thumb.src).toEqual(VALUE.url);
+
+    // Now click on the Remove button.
+    fireEvent.click(remove, {});
+    expect(wrapper.childNodes.length).toEqual(2); // Removed the thumb and remove button.
+  });
+
+});

--- a/src/FileUpload/index.js
+++ b/src/FileUpload/index.js
@@ -1,0 +1,3 @@
+import FileUpload from './FileUpload';
+
+export default FileUpload;

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import Details from './Details';
 import FormGroup from './FormGroup';
 import ErrorMessage from './ErrorMessage';
 import ErrorSummary from './ErrorSummary';
+import FileUpload from './FileUpload';
 import Heading, { LargeHeading, MediumHeading, SmallHeading, XLargeHeading } from './Heading';
 import Hint from './Hint';
 import InsetText from './InsetText';
@@ -39,6 +40,7 @@ export {
   Details,
   ErrorMessage,
   ErrorSummary,
+  FileUpload,
   FormGroup,
   Heading,
   Hint,


### PR DESCRIPTION
### Description
Added a `FileUpload` component, which presently accepts a single file at a for upload and displays a thumbnail of the selected file if it's an or otherwise "displays" an icon for the file type. The icon itself is outside the scope of this component, however, but allows application developers to override the `document-icon-{extension}` class with an appropriate style and background image.

https://support.cop.homeoffice.gov.uk/browse/COP-10567

### To test
Covered by accompanying unit tests and Storybook stories.