### PR TITLE
COP-10935: Fix uniqueness of option IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "1.6.0",
+  "version": "1.6.1-alpha",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "1.6.1-alpha",
+  "version": "1.6.1-beta",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "1.6.1-beta",
+  "version": "1.6.1-gamma",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "1.6.1-gamma",
+  "version": "1.6.1",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/Checkboxes/Checkboxes.jsx
+++ b/src/Checkboxes/Checkboxes.jsx
@@ -50,6 +50,10 @@ const Checkboxes = ({
     );
   }
 
+  const idParts = id.split('.');
+  idParts.pop();
+  idParts.push(fieldId);
+  const name = idParts.join('.');
   return (
     <div id={id} className={classes()} {...attrs}>
       {options &&
@@ -60,7 +64,7 @@ const Checkboxes = ({
             <Checkbox
               key={optionId}
               id={optionId}
-              name={`${fieldId}-${index}`}
+              name={`${name}-${index}`}
               option={option}
               selected={selected}
               onChange={updateSelection}

--- a/src/Checkboxes/Checkboxes.jsx
+++ b/src/Checkboxes/Checkboxes.jsx
@@ -54,13 +54,13 @@ const Checkboxes = ({
     <div id={id} className={classes()} {...attrs}>
       {options &&
         options.map((option, index) => {
-          const optionId = `${fieldId}-${index}`;
+          const optionId = `${id}-${index}`;
           const selected = Array.isArray(value) ? value.includes(option.value) : false;
           return (
             <Checkbox
               key={optionId}
               id={optionId}
-              name={optionId}
+              name={`${fieldId}-${index}`}
               option={option}
               selected={selected}
               onChange={updateSelection}

--- a/src/Checkboxes/Checkboxes.test.js
+++ b/src/Checkboxes/Checkboxes.test.js
@@ -32,7 +32,7 @@ describe('Checkboxes', () => {
       expect(item.classList).toContain(`${DEFAULT_CLASS}__item`);
       expect(item.innerHTML).toContain(opt.label);
       const input = item.childNodes[0];
-      expect(input.id).toEqual(`${FIELD_ID}-${index}`);
+      expect(input.id).toEqual(`${ID}-${index}`);
       expect(input.name).toEqual(`${FIELD_ID}-${index}`);
       expect(input.value).toEqual(opt.value);
       expect(input.checked).toEqual(false);

--- a/src/Radios/Radios.jsx
+++ b/src/Radios/Radios.jsx
@@ -35,7 +35,7 @@ const Radios = ({
   return (
     <div id={id} className={classes()} onChange={onChange} {...attrs}>
       {options && options.map((option, index) => {
-        const optionId = `${fieldId}-${index}`;
+        const optionId = `${id}-${index}`;
         if (typeof option === 'string') {
           return <div className={classes('divider')} key={optionId}>{option}</div>
         } else {

--- a/src/Radios/Radios.jsx
+++ b/src/Radios/Radios.jsx
@@ -32,6 +32,10 @@ const Radios = ({
       </Readonly>
     );
   }
+  const idParts = id.split('.');
+  idParts.pop();
+  idParts.push(fieldId);
+  const name = idParts.join('.');
   return (
     <div id={id} className={classes()} onChange={onChange} {...attrs}>
       {options && options.map((option, index) => {
@@ -39,7 +43,6 @@ const Radios = ({
         if (typeof option === 'string') {
           return <div className={classes('divider')} key={optionId}>{option}</div>
         } else {
-          const name = fieldId;
           const selected = typeof(value) === 'object' ? (option.value === value?.value) : (option.value === value);
           return (
             <Radio

--- a/src/Radios/Radios.jsx
+++ b/src/Radios/Radios.jsx
@@ -36,8 +36,16 @@ const Radios = ({
   idParts.pop();
   idParts.push(fieldId);
   const name = idParts.join('.');
+
+  const internalOnChange = ({ target }) => {
+    if (typeof onChange === 'function') {
+      onChange({
+        target: { name: fieldId, value: target.value }
+      });
+    }
+  };
   return (
-    <div id={id} className={classes()} onChange={onChange} {...attrs}>
+    <div id={id} className={classes()} onChange={internalOnChange} {...attrs}>
       {options && options.map((option, index) => {
         const optionId = `${id}-${index}`;
         if (typeof option === 'string') {

--- a/src/Radios/Radios.test.js
+++ b/src/Radios/Radios.test.js
@@ -49,7 +49,7 @@ describe('Radios', () => {
       expect(item.classList).toContain(`${DEFAULT_CLASS}__item`);
       expect(item.innerHTML).toContain(opt.label);
       const input = item.childNodes[0];
-      expect(input.id).toEqual(`${FIELD_ID}-${index}`);
+      expect(input.id).toEqual(`${ID}-${index}`);
       expect(input.name).toEqual(FIELD_ID);
       expect(input.value).toEqual(opt.value);
       expect(input.checked).toEqual(false);


### PR DESCRIPTION
### Description
The IDs for the options within `Radios` and `Checkboxes` were not unique across the form. They now are.

https://support.cop.homeoffice.gov.uk/browse/COP-10935

### To test
Accompanying unit tests have been updated. To test this in practice, you need to see it within a `container` or `collection` in the COP React Form Renderer.