### PR TITLE
Update onchange for radios to handle nested components and collections

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/Radios/Radio.jsx
+++ b/src/Radios/Radio.jsx
@@ -54,11 +54,7 @@ const Radio = ({
           </Hint>
         )}
       </div>
-      {selected && Array.isArray(option.nestedJSX) && <div className={classes('conditional')}>
-        {option.nestedJSX.map((nested, index) => {
-          return <React.Fragment key={option.nested[index].id}>{nested}</React.Fragment>
-        })}
-      </div>}
+      {selected && option.children && <div className={classes('conditional')}>{option.children}</div>}
     </>
   );
 };
@@ -72,13 +68,7 @@ Radio.propTypes = {
       label: PropTypes.string.isRequired,
       hint: PropTypes.string,
       disabled: PropTypes.bool,
-      nested: PropTypes.arrayOf(
-        PropTypes.shape({
-          id: PropTypes.string.isRequired,
-          label: PropTypes.string,
-          type: PropTypes.string.isRequired
-        })
-      )
+      children: PropTypes.element
     }),
     PropTypes.string
   ]).isRequired,

--- a/src/Radios/Radio.test.js
+++ b/src/Radios/Radio.test.js
@@ -125,9 +125,7 @@ describe('Radio', () => {
         type: 'date'
         }
       ],
-      nestedJSX: [
-        <DateInput id='name' fieldId='name'/>
-      ] 
+      children: <DateInput id='name' fieldId='name'/> 
     };
     
     const { container } = render(<Radio data-testid={ID} id={ID} name={FIELD_ID} option={OPTION} selected={true} />);

--- a/src/Radios/Radios.jsx
+++ b/src/Radios/Radios.jsx
@@ -28,9 +28,7 @@ const Radios = ({
     return (
       <Readonly id={id} className={className} {...attrs}>
         <div>{selectedOption?.label}</div>
-        {selectedOption?.nestedJSX?.map((nested, index) => {
-          return <div key={id + index}>{nested}</div>
-        })}
+        {selectedOption?.children}
       </Readonly>
     );
   }
@@ -40,12 +38,8 @@ const Radios = ({
   const name = idParts.join('.');
 
   const internalOnChange = ({ target }) => {
-    let output = target.name;
-    const nameParts = target.name.split('.');
-    if(nameParts.length > 1){
-      output = nameParts[1];
-    }
-    if (typeof onChange === 'function' && fieldId === output ) {
+    const truncatedName = target.name.split('.').pop();
+    if (typeof onChange === 'function' && truncatedName === fieldId) {
       onChange({
         target: { name: fieldId, value: target.value }
       });
@@ -85,7 +79,8 @@ Radios.propTypes = {
         value: PropTypes.string.isRequired,
         label: PropTypes.string.isRequired,
         hint: PropTypes.string,
-        disabled: PropTypes.bool
+        disabled: PropTypes.bool,
+        children: PropTypes.element
       }),
       PropTypes.string
     ])

--- a/src/Radios/Radios.jsx
+++ b/src/Radios/Radios.jsx
@@ -40,7 +40,12 @@ const Radios = ({
   const name = idParts.join('.');
 
   const internalOnChange = ({ target }) => {
-    if (typeof onChange === 'function') {
+    let output = target.name;
+    const nameParts = target.name.split('.');
+    if(nameParts.length > 1){
+      output = nameParts[1];
+    }
+    if (typeof onChange === 'function' && fieldId === output ) {
       onChange({
         target: { name: fieldId, value: target.value }
       });

--- a/src/Radios/Radios.stories.mdx
+++ b/src/Radios/Radios.stories.mdx
@@ -469,6 +469,8 @@ For example, you could reveal a phone number input when the user selects the ‘
           <div>
             <h2> Email Address </h2>
             <TextInput id='id' fieldId='fieldId'/>
+            <h2> Secondary Email Address </h2>
+            <TextInput id='id2' fieldId='fieldId2'/>
           </div>
         )
       }
@@ -496,13 +498,13 @@ For example, you could reveal a phone number input when the user selects the ‘
             id="conditional"
             fieldId="how-would-you-prefer-to-be-contacted"
             options={[
-              { value: 'email', label: 'Email', nestedJSX: <NestableEmail/>, nested: {
+              { value: 'email', label: 'Email', children: <NestableEmail/>, nested: {
                 id: 'email'
               }},
-              { value: 'phone', label: 'Phone', nestedJSX: <NestablePhone/>, nested: {
+              { value: 'phone', label: 'Phone', children: <NestablePhone/>, nested: {
                 id: 'phone'
               }},
-              { value: 'textMessage', label: 'Text message', nestedJSX: <NestableMobile/>, nested: {
+              { value: 'textMessage', label: 'Text message', children: <NestableMobile/>, nested: {
                 id: 'textMessage'
               }},
             ]}


### PR DESCRIPTION
The onChange function within the radios component was submitting all changes it caught with the fieldId of the Radios component, this meant that changes to nested components were being caught and also passed up as changes with the Radios fieldId. The value for the Radios component was then set to the value of the nested component. 

Collections have component names like `people[0].title` where as things outside of collections would just have names like `title`. This PR deconstructs the collection names to extract the original fieldId and then only calls onChange if the change has actually originated from the Radios component. Changes to the nested component are passed up by their own onChange handlers.