### PR TITLE
COP-10967: Fix DateInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/DateInput/DateInput.test.js
+++ b/src/DateInput/DateInput.test.js
@@ -147,9 +147,10 @@ describe('DateInput', () => {
     //day
     const dayInput = wrapper.childNodes[0].childNodes[1];
     expect(dayInput.value).toEqual('6');
-    fireEvent.change(dayInput, { target: { name: `${FIELD_ID}-day`, value: 12 } });
     expect(onChangeCalls.length).toEqual(1);
-    expect(onChangeCalls[0]).toMatchObject({
+    fireEvent.change(dayInput, { target: { name: `${FIELD_ID}-day`, value: 12 } });
+    expect(onChangeCalls.length).toEqual(2);
+    expect(onChangeCalls[1]).toMatchObject({
       target: {
         name: FIELD_ID,
         value: '12-3-2076'
@@ -160,13 +161,13 @@ describe('DateInput', () => {
     const monthInput = wrapper.childNodes[1].childNodes[1];
     expect(monthInput.value).toEqual('3');
     fireEvent.change(monthInput, { target: { value: 2 } });
-    expect(onChangeCalls.length).toEqual(2);
+    expect(onChangeCalls.length).toEqual(3);
 
     //year
     const yearInput = wrapper.childNodes[2].childNodes[1];
     expect(yearInput.value).toEqual('2076');
     fireEvent.change(yearInput, { target: { value: 1999 } });
-    expect(onChangeCalls.length).toEqual(3);
+    expect(onChangeCalls.length).toEqual(4);
   });
 
   it('should appropriately set up the necessary components when read only', async () => {


### PR DESCRIPTION
### Description
Fixes an issue where changing the `value` externally results in an endless loop.

https://support.cop.homeoffice.gov.uk/browse/COP-10967

### To test
Covered by unit tests. However, you can see the broken behaviour in the COP React Form Renderer with the following steps:
1. Set up the JSON to have a date field;
2. Set up the initial data to have a valid value for that date field;
3. Switch to the Preview tab and you'll see the value appropriately showing in the date field;
4. Go back to the initial date and change to another valid value for the date field;
5. Switch back to the Preview tab and you'll now see the value in the date field flicking between the old and new values.

This has been fixed but until this has been merged and published to npm, it will continue to be broken in the Form Renderer. I'll raise a separate PR to bring that fix into there.