### PR TITLE
Add react-select to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "accessible-autocomplete": "2.0.3",
     "govuk-frontend": "^3.13.0",
     "html-react-parser": "^0.10.5",
+    "react-select": "^3.2.0",
     "web-vitals": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description
When this library was being consumed by something else, it required the something else to set up `react-select` as a dependency or it would fail.