### PR TITLE
COP-10967: Fix TimeInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/TimeInput/TimeInput.test.js
+++ b/src/TimeInput/TimeInput.test.js
@@ -121,8 +121,8 @@ describe('TimeInput', () => {
     const hourInput = wrapper.childNodes[0].childNodes[1];
     expect(hourInput.value).toEqual('14');
     fireEvent.change(hourInput, {target: {name: `${FIELD_ID}-hour`, value: 20 }});
-    expect(onChangeCalls.length).toEqual(1);
-    expect(onChangeCalls[0]).toMatchObject({ target:{
+    expect(onChangeCalls.length).toEqual(2);
+    expect(onChangeCalls[1]).toMatchObject({ target:{
       name:FIELD_ID,
       value: '20:30'
     }});
@@ -131,8 +131,8 @@ describe('TimeInput', () => {
     const minuteInput = wrapper.childNodes[1].childNodes[1];
     expect(minuteInput.value).toEqual('30');
     fireEvent.change(minuteInput, {target: {name: `${FIELD_ID}-minute`, value: 40 }});
-    expect(onChangeCalls.length).toEqual(2);
-    expect(onChangeCalls[1]).toMatchObject({ target:{
+    expect(onChangeCalls.length).toEqual(3);
+    expect(onChangeCalls[2]).toMatchObject({ target:{
       name:FIELD_ID,
       value: '20:40'
     }});


### PR DESCRIPTION
### Description
Fixes an issue where changing the `value` externally results in an endless loop. This was already fixed for the `DateInput` in a similar way.

https://support.cop.homeoffice.gov.uk/browse/COP-10967

### To test
Covered by unit tests. However, you can see the broken behaviour in the COP React Form Renderer with the following steps:
1. Set up the JSON to have a time field;
2. Set up the initial data to have a valid value for that time field;
3. Switch to the Preview tab and you'll see the value appropriately showing in the time field;
4. Go back to the initial time and change to another valid value for the time field;
5. Switch back to the Preview tab and you'll now see the value in the time field flicking between the old and new values.

This has been fixed but until this has been merged and published to npm, it will continue to be broken in the Form Renderer. I'll raise a separate PR to bring that fix into there.