### PR TITLE
Fix issue with nested file upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "1.7.4",
+  "version": "1.7.5-alpha",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "1.7.5-alpha",
+  "version": "1.7.5",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/FileUpload/FileUpload.jsx
+++ b/src/FileUpload/FileUpload.jsx
@@ -100,6 +100,10 @@ const FileUpload = ({
       </Readonly>
     );
   }
+  const idParts = id.split('.');
+  idParts.pop();
+  idParts.push(fieldId);
+  const name = idParts.join('.');
 
   return (
     <div className={classes()} disabled={disabled}>
@@ -109,11 +113,11 @@ const FileUpload = ({
         onChange={onFileSelected}
         disabled={disabled}
         id={`${id}-select`}
-        name={`${fieldId}-select`}
+        name={`${name}-select`}
         type="file"
         className={classes('select')}
       />
-      <label htmlFor={`${fieldId}-select`} className={classes('label')}>
+      <label htmlFor={`${name}-select`} className={classes('label')}>
         <span className={classes('label-button')}>Choose file</span>
         {value?.name ? (
           <span className={classes('label-filename')}>{value.name}</span>


### PR DESCRIPTION
### Description
Fixed an issue with a nested file upload where the label's `htmlFor` didn't match the name of the file input so clicking on it did nothing.