### PR TITLE
Fix invalid style import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "1.8.1",
+  "version": "1.8.2-alpha",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/ButtonGroup/ButtonGroup.scss
+++ b/src/ButtonGroup/ButtonGroup.scss
@@ -1,5 +1,5 @@
 @import "node_modules/govuk-frontend/govuk/_base";
-@import "govuk-frontend/govuk/objects/_button-group";
+@import "node_modules/govuk-frontend/govuk/objects/_button-group";
 
 .hods-button-group {
   @extend .govuk-button-group;


### PR DESCRIPTION
### Description
Fixed an invalid style import. We can't import from `"govuk-frontend/*"` - we should import from `"node_modules/govuk-frontend/*"`.