### PR TITLE
Added functionality for exclusive checkboxes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "1.9.5",
+  "version": "1.10.0",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/Checkboxes/Checkboxes.jsx
+++ b/src/Checkboxes/Checkboxes.jsx
@@ -24,13 +24,41 @@ const Checkboxes = ({
 }) => {
   const classes = classBuilder(classBlock, classModifiers, className);
 
+  // Selection is an array of the options which have been selected
+  // Exclusive Flag is true when an option with the exclusive behaviour is checked
+  // Exclusive Option is the value of the checked exclusive option
   const [selection, setSelection] = useState(value ? value : []);
+  const [exclusiveFlag, setExclusiveFlag] = useState(false);
+  const [exclusiveOption, setExclusiveOption] = useState('');
+  const [nonExclusiveOption, setNonExclusiveOption] = useState('');
 
-  const updateSelection = ({ target }) => {
-    if (target.checked) {
-      setSelection((prev) => [...prev, target.value]);
+  const updateSelection = (event, option) => {
+    // Destructs the event target (checkbox) to its value and checked boolean
+    // Passing option here allows us to expose the 'behaviour' field
+    const { value: targetValue, checked: isTargetChecked } = event.target;
+
+    // console.log(`targetValue = ${targetValue}, isTargetChecked = ${isTargetChecked}, option = ${JSON.stringify(option, null, 2)}`)
+
+    // If this checkbox is checked then update the selection array with its value
+    if (isTargetChecked) {
+      setSelection((prev) => [...prev, targetValue]);
     } else {
-      setSelection((prev) => prev.filter((s) => s !== target.value));
+      setSelection((prev) => prev.filter((s) => s !== targetValue));
+    }
+
+    // If this option's behaviour is set to 'exclusive' and is checked then set the
+    // exclusiveFlag to true, update the exclusive option to its value and reset the
+    // selection array to only its value
+    if (option.behaviour === 'exclusive') {
+      setExclusiveFlag(isTargetChecked);
+      if (isTargetChecked) {
+        setExclusiveOption(option.value);
+        setSelection([option.value]);
+      }
+    } else if (exclusiveFlag && isTargetChecked) {
+      setExclusiveFlag(false);
+      setNonExclusiveOption([option.value]);
+      setSelection([option.value]);
     }
   };
 
@@ -38,7 +66,30 @@ const Checkboxes = ({
     if (typeof onChange === 'function' && selection !== value) {
       onChange({ target: { name: fieldId, value: selection } });
     }
-  }, [selection, onChange, fieldId, value]);
+
+    // Get a list of the checkbox components
+    const checkboxes = document.querySelectorAll('input[type="checkbox"]');
+
+    // If the checkbox isn't the exclusive option and the flag is on then uncheck it
+    for (let checkbox of checkboxes) {
+      // console.log(`checkbox = ${checkbox.value}, exclusive option = ${exclusiveOption}`)
+      if (
+        (checkbox.value !== exclusiveOption && exclusiveFlag) ||
+        (checkbox.value === exclusiveOption && !exclusiveFlag)
+      ) {
+        // Either: this isn't the exclusive checkbox and the flag is on so uncheck it
+        // or: this is the exclusive checkbox but the flag is not on so uncheck it
+        checkbox.checked = false;
+      } else if (
+        checkbox.value === nonExclusiveOption &&
+        exclusiveOption !== '' &&
+        !exclusiveFlag) {
+        // This isn't the non-exclusive option and the flag is not on so check it
+        checkbox.checked = true;
+      }
+    }
+
+  }, [selection, onChange, fieldId, value, exclusiveFlag, exclusiveOption, nonExclusiveOption]);
 
   if (readonly) {
     return (
@@ -59,20 +110,28 @@ const Checkboxes = ({
       {options &&
         options.map((option, index) => {
           const optionId = `${id}-${index}`;
+
+          // Checks if this option is in the selection array
           const selected = Array.isArray(value) ? value.includes(option.value) : false;
-          return (
-            <Checkbox
-              key={optionId}
-              id={optionId}
-              name={`${name}-${index}`}
-              option={option}
-              selected={selected}
-              onChange={updateSelection}
-              classBlock={classBlock}
-              classModifiers={classModifiers}
-              className={className}
-            />
-          );
+
+          // Adds a divider between options
+          if (typeof option === 'string') {
+            return <div className={classes('divider')} key={optionId}>{option}</div>;
+          } else {
+            return (
+              <Checkbox
+                key={optionId}
+                id={optionId}
+                name={`${name}-${index}`}
+                option={option}
+                selected={selected}
+                onChange={event => updateSelection(event, option)}
+                classBlock={classBlock}
+                classModifiers={classModifiers}
+                className={className}
+              />
+            );
+          }
         })}
     </div>
   );
@@ -88,6 +147,7 @@ Checkboxes.propTypes = {
         label: PropTypes.string.isRequired,
         hint: PropTypes.string,
         disabled: PropTypes.bool,
+        behaviour: PropTypes.string,
       }),
       PropTypes.string,
     ])

--- a/src/Checkboxes/Checkboxes.stories.mdx
+++ b/src/Checkboxes/Checkboxes.stories.mdx
@@ -69,20 +69,21 @@ Do not use the checkboxes component if users can only choose one option from a s
 ## How it works
 
 Always position checkboxes to the left of their labels. This makes them easier to find, especially for users of screen magnifiers.
-Í
+
 Unlike with radios, users can select multiple options from a list of checkboxes. Do not assume that users will know how many options they can select based on the visual difference between radios and checkboxes alone.
 
 If needed, add a hint explaining this, for example, 'Select all that apply'.
 
 Do not pre-select checkbox options as this makes it more likely that users will:
 
-not realise they've missed a question
-submit the wrong answer
+- not realise they've missed a question
+- submit the wrong answer
+
 Order checkbox options alphabetically by default.
 
-In some cases, it can be helpful to order them from most-to-least common options. For example, you could order options for 'What is your nationality?'' based on population size.
+In some cases, it can be helpful to order them from most-to-least common options. For example, you could order options for 'What is your nationality?' based on population size.
 
-Group checkboxes together in a <fieldset\> with a <legend\> that describes them, as shown in the examples on this page. This is usually a question, like 'How would you like to be contacted?''.
+Group checkboxes together in a <fieldset\> with a <legend\> that describes them, as shown in the examples on this page. This is usually a question, like 'How would you like to be contacted?'.
 
 ### If you’re asking one question on the page
 
@@ -182,6 +183,45 @@ You can add hints to checkbox items to provide additional information about the 
             value: 'CitizenOfAnotherCountry',
             label: 'Citizen of another country',
           },
+        ]}
+      />
+    </FormGroup>
+  </Story>
+</Canvas>
+
+### Checkbox items with divider
+
+You can split checkbox items with a divider to ensure the user is able to 
+select options from the list **or** the exclusive option.
+
+<Canvas>
+  <Story name='With Divider'>
+    <FormGroup
+      id='standard'
+      label={<h1 className='govuk-heading-l'>Which of these is the company involved in?</h1>}
+    >
+      <Checkboxes
+        id='activities'
+        fieldId='activities'
+        options={[
+          {
+            value: 'immigration',
+            label: 'Immigration or customs work, including interpretation services'
+          },
+          {
+            value: 'politics',
+            label: 'Political activity'
+          },
+          {
+            value: 'transport',
+            label: 'Transporting people or goods across international borders'
+          },
+          'or',
+          {
+            value: 'conflict',
+            label: 'Activities that potentially conflict with Border Force',
+            behaviour: 'exclusive'
+          }
         ]}
       />
     </FormGroup>

--- a/src/Checkboxes/Checkboxes.test.js
+++ b/src/Checkboxes/Checkboxes.test.js
@@ -111,4 +111,212 @@ describe('Checkboxes', () => {
     expect(checkboxItems[2].childNodes[0].checked).toEqual(true); //Third option Wales
 
   });
+
+  it('should create a divider between checkboxes', async () => {
+    const ID = 'checkboxes';
+    const FIELD_ID = 'checkboxesFieldId';
+
+    // Create OPTIONS with divider
+    const OPTIONS_WITH_DIVIDER = [
+      { value: 'england', label: 'England' },
+      { value: 'scotland', label: 'Scotland' },
+      'or',
+      { value: 'wales', label: 'Wales' },
+      { value: 'northern-ireland', label: 'Northern Ireland' },
+    ];
+
+    // Build checkboxes
+    const { container } = render(
+      <Checkboxes
+        data-testid={ID}
+        id={ID}
+        fieldId={FIELD_ID}
+        options={OPTIONS_WITH_DIVIDER}
+      />
+    );
+
+    const wrapper = checkSetup(container, ID);
+
+    // Expected number of HTML elements to be same as provided options
+    expect(wrapper.childNodes.length).toEqual(OPTIONS_WITH_DIVIDER.length);
+
+    // Expect divider fields to be correct
+    const divider = wrapper.childNodes[2];
+    expect(divider.classList).toContain(`${DEFAULT_CLASS}__divider`);
+    expect(divider.innerHTML).toEqual(`or`);
+  });
+
+  it('should deselect all other options when an exclusive option is checked', async () => {
+    const ID = 'checkboxes';
+    const FIELD_ID = 'checkboxesFieldId';
+
+    // Create OPTIONS with an exclusive option
+    const OPTIONS_WITH_EXCLUSIVE = [
+      { value: 'england', label: 'England' },
+      { value: 'scotland', label: 'Scotland' },
+      { value: 'wales', label: 'Wales' },
+      { value: 'northern-ireland', label: 'Northern Ireland' },
+      { 
+        value: 'citizen-of-another-country',
+        label: 'Citizen Of Another Country',
+        behaviour: 'exclusive'
+      },
+    ];
+    const EXCLUSIVE_OPTIONS = [
+      {
+        value: 'citizen-of-another-country',
+        label: 'Citizen Of Another Country',
+        behaviour: 'exclusive'
+      }
+    ];
+    const NON_EXCLUSIVE_OPTIONS = [
+      { value: 'england', label: 'England' },
+      { value: 'scotland', label: 'Scotland' },
+      { value: 'wales', label: 'Wales' },
+      { value: 'northern-ireland', label: 'Northern Ireland' }
+    ];
+
+    // Build checkboxes
+    const { container } = render(
+      <Checkboxes
+        data-testid={ID}
+        id={ID}
+        fieldId={FIELD_ID}
+        options={OPTIONS_WITH_EXCLUSIVE}
+      />
+    );
+
+    const wrapper = checkSetup(container, ID);
+
+    // Set all non-exclusive options to checked
+    NON_EXCLUSIVE_OPTIONS.forEach((opt) => {
+      const indexOfOption = OPTIONS_WITH_EXCLUSIVE.findIndex(OPTION => OPTION.value === opt.value);
+      const item = wrapper.childNodes[indexOfOption];
+      const input = item.childNodes[0];
+      fireEvent.click(document.getElementById(input.id));
+    });
+
+    // Expect all non-exclusive options to be checked
+    NON_EXCLUSIVE_OPTIONS.forEach((opt) => {
+      const indexOfOption = OPTIONS_WITH_EXCLUSIVE.findIndex(OPTION => OPTION.value === opt.value);
+      const item = wrapper.childNodes[indexOfOption];
+      const input = item.childNodes[0];
+      expect(input.checked).toEqual(true);
+    });
+
+    // Expect the exclusive option to be not checked
+    EXCLUSIVE_OPTIONS.forEach((opt) => {
+      const indexOfOption = OPTIONS_WITH_EXCLUSIVE.findIndex(OPTION => OPTION.value === opt.value);
+      const item = wrapper.childNodes[indexOfOption];
+      const input = item.childNodes[0];
+      expect(input.checked).toEqual(false);
+    })
+
+    // Set the exclusive option to checked
+    EXCLUSIVE_OPTIONS.forEach((opt) => {
+      const indexOfOption = OPTIONS_WITH_EXCLUSIVE.findIndex(OPTION => OPTION.value === opt.value);
+      const item = wrapper.childNodes[indexOfOption];
+      const input = item.childNodes[0];
+      fireEvent.click(document.getElementById(input.id));
+    });
+
+    // Expect the exclusive option to be checked
+    EXCLUSIVE_OPTIONS.forEach((opt) => {
+      const indexOfOption = OPTIONS_WITH_EXCLUSIVE.findIndex(OPTION => OPTION.value === opt.value);
+      const item = wrapper.childNodes[indexOfOption];
+      const input = item.childNodes[0];
+      expect(input.checked).toEqual(true);
+    });
+
+    // Expect all non-exclusive options to be now be not checked
+    NON_EXCLUSIVE_OPTIONS.forEach((opt) => {
+      const indexOfOption = OPTIONS_WITH_EXCLUSIVE.findIndex(OPTION => OPTION.value === opt.value);
+      const item = wrapper.childNodes[indexOfOption];
+      const input = item.childNodes[0];
+      expect(input.checked).toEqual(false);
+    });
+  });
+
+  it('should deselect all exclusive options when a non-exclusive option is checked', async () => {
+    const ID = 'checkboxes';
+    const FIELD_ID = 'checkboxesFieldId';
+
+    // Create OPTIONS with an exclusive option
+    const OPTIONS_WITH_EXCLUSIVE = [
+      { value: 'england', label: 'England' },
+      { value: 'scotland', label: 'Scotland' },
+      { value: 'wales', label: 'Wales' },
+      { value: 'northern-ireland', label: 'Northern Ireland' },
+      { 
+        value: 'citizen-of-another-country',
+        label: 'Citizen Of Another Country',
+        behaviour: 'exclusive'
+      },
+    ];
+    const EXCLUSIVE_OPTIONS = [
+      {
+        value: 'citizen-of-another-country',
+        label: 'Citizen Of Another Country',
+        behaviour: 'exclusive'
+      }
+    ];
+    const NON_EXCLUSIVE_OPTIONS = [
+      { value: 'england', label: 'England' },
+      { value: 'scotland', label: 'Scotland' },
+      { value: 'wales', label: 'Wales' },
+      { value: 'northern-ireland', label: 'Northern Ireland' }
+    ];
+
+    // Build checkboxes
+    const { container } = render(
+      <Checkboxes
+        data-testid={ID}
+        id={ID}
+        fieldId={FIELD_ID}
+        options={OPTIONS_WITH_EXCLUSIVE}
+      />
+    );
+
+    const wrapper = checkSetup(container, ID);
+
+    // Set the exclusive option to checked
+    EXCLUSIVE_OPTIONS.forEach((opt) => {
+      const indexOfOption = OPTIONS_WITH_EXCLUSIVE.findIndex(OPTION => OPTION.value === opt.value);
+      const item = wrapper.childNodes[indexOfOption];
+      const input = item.childNodes[0];
+      fireEvent.click(document.getElementById(input.id));
+    });
+
+    // Expect the exclusive option to be checked
+    EXCLUSIVE_OPTIONS.forEach((opt) => {
+      const indexOfOption = OPTIONS_WITH_EXCLUSIVE.findIndex(OPTION => OPTION.value === opt.value);
+      const item = wrapper.childNodes[indexOfOption];
+      const input = item.childNodes[0];
+      expect(input.checked).toEqual(true);
+    });
+
+    // Expect the non-exclusive options to be not checked
+    NON_EXCLUSIVE_OPTIONS.forEach((opt) => {
+      const indexOfOption = OPTIONS_WITH_EXCLUSIVE.findIndex(OPTION => OPTION.value === opt.value);
+      const item = wrapper.childNodes[indexOfOption];
+      const input = item.childNodes[0];
+      expect(input.checked).toEqual(false);
+    })
+
+    // Set all non-exclusive options to checked
+    NON_EXCLUSIVE_OPTIONS.forEach((opt) => {
+      const indexOfOption = OPTIONS_WITH_EXCLUSIVE.findIndex(OPTION => OPTION.value === opt.value);
+      const item = wrapper.childNodes[indexOfOption];
+      const input = item.childNodes[0];
+      fireEvent.click(document.getElementById(input.id));
+    });
+
+    // Expect the exclusive option to be now not checked
+    EXCLUSIVE_OPTIONS.forEach((opt) => {
+      const indexOfOption = OPTIONS_WITH_EXCLUSIVE.findIndex(OPTION => OPTION.value === opt.value);
+      const item = wrapper.childNodes[indexOfOption];
+      const input = item.childNodes[0];
+      expect(input.checked).toEqual(false);
+    });
+  });
 });


### PR DESCRIPTION
## Description

This update enables the following two features:

### 1. Dividers
Allows you to add a divider as a string to separate checkboxes
### 2. Exclusive checkbox options
Enables the user to select an 'exclusive' checkbox which, when selected, deselects all other checkboxes. Upon re-selecting any other checkbox, this 'exclusive' checkbox deselects.
This is mainly to enable the use of a 'None of the above' checkbox but can have other applications. This is done by adding the 'behaviour' field with the value of 'exclusive' for the necessary option(s) as shown below:
`{ 
    value: 'citizen-of-another-country',
    label: 'Citizen Of Another Country',
    behaviour: 'exclusive'
  }`

## Testing

An extra checkboxes example has been added to the bottom of the checkboxes.stories.mdx file

1. Run yarn storybook
2. Navigate to Checkboxes
3. Scroll to the 'Checkbox items with divider' example
4. Check at least one of the first three options
5. Observe that any combination of these checkboxes can be checked
6. Select the option after the 'or' divider
7. Observe that the previously selected option(s) is/are now unchecked
8. Reselect one of the first three options
9. Observe that the vice versa happens

Unit tests have also been written to confirm the following where a checkbox selection has been simulated using fireEvent:

- A divider is created with the expected properties
- Step 7 above occurs as expected
- Step 9 above occurs as expected

Link to JIRA ticket is here: [JIRA Ticket 2182](https://support.cop.homeoffice.gov.uk/secure/RapidBoard.jspa?rapidView=2&view=detail&selectedIssue=CO-2182)