### PR TITLE
EAB-583 Enabled autocomplete to use select functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-components",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/Autocomplete/Autocomplete.jsx
+++ b/src/Autocomplete/Autocomplete.jsx
@@ -22,6 +22,8 @@ const Autocomplete = ({
   value,
   defaultValue,
   displayMenu,
+  showAllValues,
+  placeholder,
   templates: _templates,
   onChange,
   onConfirm: _onConfirm,
@@ -69,9 +71,10 @@ const Autocomplete = ({
         displayMenu={displayMenu}
         onConfirm={onConfirm}
         confirmOnBlur={false}
-        showAllValues={false}
+        showAllValues={showAllValues}
         templates={templates}
         source={filterFunction}
+        placeholder={placeholder}
       />}
     </div>
   );
@@ -97,6 +100,10 @@ Autocomplete.propTypes = {
   defaultValue: PropTypes.any,
   /** Whether the menu of items should overlay elements below it or move those elements down the page. */
   displayMenu: PropTypes.oneOf(['overlay', 'inline']),
+  /** Whether or not all values should be shown when the input is selected. */
+  showAllValues: PropTypes.bool,
+  /** The text that should appear in the input when it is empty. */
+  placeholder: PropTypes.string,
   /** Functions for formatting the labels that appear in the options menu and in the input when a selection is made. */
   templates: PropTypes.shape({ inputValue: PropTypes.func.isRequired, suggestion: PropTypes.func.isRequired }),
   /** Handler for when the value changes. */

--- a/src/Autocomplete/Autocomplete.scss
+++ b/src/Autocomplete/Autocomplete.scss
@@ -23,7 +23,6 @@ $govuk-font-family: 'Roboto', arial, sans-serif;
   }
 
   &__dropdown-arrow-down {
-    z-index: -1;
     display: inline-block;
     position: absolute;
     right: 8px;


### PR DESCRIPTION
### Description
This enables the autocomplete component to be configured to act like a select component - allowing the user to select an option using the mouse. This functionality already existed in the Accessible Autocomplete that our autocomplete component wraps, it just needed exposing so it could be configured in Form Renderer JSON files.

### Testing
To test this functionality, there are now two extra options that can be set within a Form Renderer JSON file when defining an autocomplete component:

```
"showAllValues": true,
```
This option will display a select-style list of all options available as soon as the autocomplete is focused. A user can either select a value from this list, or begin typing to filter the list just as in a standard autocomplete field. Setting this option to `true` will render the autocomplete with a select-style arrow.

```
"placeholder": "Start typing or click to select a value...",
```
This option specifies placeholder text that should appear in the field if no value is selected.

Both options can be used independently of one another.
